### PR TITLE
fix: fit the board and lobby to any viewport height

### DIFF
--- a/client/app/globals.css
+++ b/client/app/globals.css
@@ -2,6 +2,31 @@
 
 @custom-variant dark (&:where(.dark, .dark *));
 
+/* Height-constrained viewports (fullscreen AND half-tiled 1080p windows,
+   1366x768 laptops, 150% OS zoom): the board's fixed chrome (header, badges,
+   action bar) is what overflows — cards already scale via svh. `short:`
+   compresses that chrome. 60rem (960px) deliberately covers a maximized
+   browser on a 1080p screen (~905-945px of viewport): the stacked seat
+   header only truly fits ~1000px+, and a threshold below that gave 850-960px
+   viewports a WORSE fit than 750px ones. Discrete layout changes (flattening
+   a stacked badge) need the variant; prefer continuous clamp(...svh...)
+   values where they suffice. */
+@custom-variant short {
+  @media (max-height: 60rem) {
+    @slot;
+  }
+}
+
+/* Very short (≤680px): 150%-zoom laptops and 1366x768 screens. The seat
+   header moves BESIDE the hand (see PlayerHandStrip) — at these heights the
+   ~30px it costs above each hand is exactly the difference between fitting
+   and scrolling, while width is abundant. Matches the --card-w step below. */
+@custom-variant vshort {
+  @media (max-height: 42.5rem) {
+    @slot;
+  }
+}
+
 /* ============================================================================
    Design tokens — "The Clean One, multiplayer" (Round 4 visual identity)
    Four roles per theme: ground / surface / ink / accent (+ surface-2,
@@ -148,6 +173,22 @@
 
   --radius-card: 0.625rem;
   --radius-pill: 9999px;
+}
+
+/* One card size for the whole table — hands (regular cells), the deck, the
+   discard pile and the drawn-card slot all read this var (w-(--card-w)), so
+   the table scales as a unit. svh (not vh): stable while mobile browser
+   chrome collapses; 15vw keeps portrait phones width-bound. Below ~680px of
+   height even 8svh cards can't fit next to the board chrome, so the whole
+   table steps down together. (Dense opponent cells keep their own formula —
+   they are width-bound and capped, not height-bound.) */
+:root {
+  --card-w: min(8svh, 15vw);
+}
+@media (max-height: 42.5rem) {
+  :root {
+    --card-w: min(7.5svh, 15vw);
+  }
 }
 
 .no-native-cursor * {

--- a/client/components/cards/VisualCardStack.tsx
+++ b/client/components/cards/VisualCardStack.tsx
@@ -74,7 +74,7 @@ export const VisualCardStack = ({
         transition={cardTravelTransition}
         onClick={onClick}
         className={cn(
-          "relative w-[min(8vh,15vw)] aspect-[5/7] rounded-card",
+          "relative w-(--card-w) aspect-[5/7] rounded-card",
           canInteract
             ? "cursor-pointer transition-[filter] hover:brightness-110"
             : "cursor-default",

--- a/client/components/game/ActionBarComponent.tsx
+++ b/client/components/game/ActionBarComponent.tsx
@@ -89,7 +89,7 @@ const ActionBarComponent: React.FC = () => {
 
   return (
     <motion.div
-      className="flex flex-col items-center w-full"
+      className="flex h-full w-full flex-col items-center"
       initial={{ y: 20, opacity: 0 }}
       animate={{ y: 0, opacity: 1 }}
       transition={{
@@ -100,7 +100,7 @@ const ActionBarComponent: React.FC = () => {
       <motion.div
         layout
         transition={{ type: "spring", stiffness: 400, damping: 35 }}
-        className="flex flex-row flex-wrap items-center justify-center gap-2 rounded-full border border-hairline bg-surface p-2 shadow-lg"
+        className="flex shrink-0 flex-row flex-wrap items-center justify-center gap-2 rounded-full border border-hairline bg-surface p-2 shadow-lg"
       >
         {actions.map((action, i) => (
           <ActionButton
@@ -110,11 +110,14 @@ const ActionBarComponent: React.FC = () => {
         ))}
       </motion.div>
 
-      {/* Fixed-height slot: the prompt fades in place and can wrap to two
-          lines without ever changing the bar's height (which would reflow
-          the whole board). */}
+      {/* Flexible slot: the bar fills its fixed grid row (h-full) and the
+          prompt takes whatever is left between the pill and the timer rail,
+          so the bar can NEVER outgrow the row — the old fixed slot height
+          plus svh margins drifted a few px past the row's own clamp on
+          short viewports, which surfaced as a phantom board scrollbar. The
+          prompt still fades in place without changing the bar's height. */}
       <div
-        className="mt-2 flex h-10 items-start justify-center"
+        className="mt-[clamp(0.25rem,1svh,0.5rem)] flex min-h-0 flex-1 items-start justify-center overflow-hidden"
         aria-live="polite"
       >
         <AnimatePresence>
@@ -140,7 +143,7 @@ const ActionBarComponent: React.FC = () => {
           in one cell. As flex siblings they sat side by side during the
           crossfade — the new bar mounted half a bar-width off-center and
           snapped back when the exit finished (the "teleporting" bar). */}
-      <div className="mt-1 grid h-1 w-full items-center justify-items-center">
+      <div className="mt-1 grid h-1 w-full shrink-0 items-center justify-items-center">
         <AnimatePresence>
           {timedIndicator && remainingMs > 0 && countdownRevealed && (
             <motion.div

--- a/client/components/game/GameBoard.tsx
+++ b/client/components/game/GameBoard.tsx
@@ -85,7 +85,7 @@ const GameStateError = ({
 };
 
 const LoadingIndicator = () => (
-  <div className="flex items-center justify-center h-screen w-full bg-ground">
+  <div className="flex items-center justify-center h-full w-full bg-ground">
     <p className="font-game text-ink-muted">Loading Game...</p>
   </div>
 );
@@ -214,15 +214,20 @@ export function GameBoard() {
   };
 
   return (
-    <div className="relative h-screen w-full bg-ground flex flex-col overflow-hidden @container font-game">
+    <div className="relative h-full w-full bg-ground flex flex-col overflow-hidden @container font-game">
       <GameHeader />
       {/* CHECK's recede is momentary and returns to identity. A HELD scale
           here (the R12 end-of-round recede) made every layout-projected card
           under it fight the projection system on Gecko — the board bounced
           up and down indefinitely. The end scene now makes room with real
           layout (row order + hidden rows) instead of a transform. */}
+      {/* min-h-0 + overflow-y-auto: when a viewport is shorter than even the
+          compressed board (extreme zoom, tiny windows), the grid scrolls
+          instead of silently clipping the action bar — a button that exists
+          but can't be reached is the one unacceptable failure mode. At every
+          size the short/svh trims are tuned for, no scrollbar appears. */}
       <motion.div
-        className="relative flex-1 grid grid-rows-[auto_auto_1fr_auto_auto]"
+        className="relative flex-1 min-h-0 overflow-y-auto overflow-x-hidden grid grid-rows-[auto_auto_1fr_auto_auto]"
         animate={{ scale: checkMoment && !reducedMotion ? 0.92 : 1 }}
         transition={{ duration: 0.4, ease: "easeOut" }}
         style={{ transformOrigin: "center" }}
@@ -246,7 +251,7 @@ export function GameBoard() {
             {/* Opponents area */}
             <div
               className={cn(
-                "flex justify-center items-center py-2",
+                "flex justify-center items-center py-[clamp(0.125rem,0.75svh,0.5rem)]",
                 endScene && "order-1",
               )}
             >
@@ -299,12 +304,12 @@ export function GameBoard() {
             {/* Table Area - takes up remaining space. Extra vertical padding
                 gives the center decks breathing room from the opponent band
                 above and the local hand below (they read cramped without it);
-                the 1fr row absorbs it, and the @md guard keeps it modest on
-                dense phone layouts. */}
+                the 1fr row absorbs it, and the svh clamp scales it away
+                first on height-starved viewports. */}
             <div
               className={cn(
                 "flex items-center justify-center @container",
-                endScene ? "order-3" : "py-4 @md:py-8",
+                endScene ? "order-3" : "py-[clamp(0.25rem,3svh,1.25rem)]",
               )}
             >
               <TableArea
@@ -318,7 +323,7 @@ export function GameBoard() {
                 collapses) rather than duplicating the hand. */}
             <div
               className={cn(
-                "flex flex-col items-center justify-center py-2",
+                "flex flex-col items-center justify-center py-[clamp(0.125rem,0.75svh,0.5rem)]",
                 endScene && "order-2",
               )}
             >
@@ -342,7 +347,7 @@ export function GameBoard() {
                 every phase change. Retired for the end scene (it would be an
                 empty pill floating under the results panel). */}
             {!endScene && (
-              <div className="h-28 @md:h-32 flex items-start justify-center pb-2">
+              <div className="h-[clamp(6rem,15svh,7rem)] flex items-start justify-center">
                 <ActionControllerView />
               </div>
             )}

--- a/client/components/game/GameEventCaption.tsx
+++ b/client/components/game/GameEventCaption.tsx
@@ -97,7 +97,7 @@ export const GameEventCaption = () => {
 
   return (
     <div
-      className="flex h-8 items-center justify-center font-game"
+      className="flex h-[clamp(1.5rem,4svh,1.75rem)] items-center justify-center font-game"
       aria-live="polite"
     >
       <AnimatePresence mode="wait">

--- a/client/components/game/GameHeader.tsx
+++ b/client/components/game/GameHeader.tsx
@@ -89,7 +89,7 @@ export const GameHeader = () => {
   };
 
   return (
-    <header className="relative z-20 flex h-14 shrink-0 items-center justify-between border-b border-hairline bg-ground px-4 font-game md:px-6">
+    <header className="relative z-20 flex h-14 shrink-0 items-center justify-between border-b border-hairline bg-ground px-4 font-game md:px-6 short:h-12">
       <div className="flex min-w-0 items-center gap-3">
         <Link
           href="/"

--- a/client/components/game/GameLobby.tsx
+++ b/client/components/game/GameLobby.tsx
@@ -260,7 +260,7 @@ export const GameLobby = () => {
 
   if (isLoading) {
     return (
-      <div className="flex min-h-dvh w-full flex-col items-center justify-center gap-4 bg-ground font-game">
+      <div className="flex h-full w-full flex-col items-center justify-center gap-4 bg-ground font-game">
         <div className="h-10 w-10 animate-spin rounded-full border-2 border-hairline border-t-ink" />
         <p className="text-ink-muted">
           {reconnectionTimeout
@@ -335,8 +335,15 @@ export const GameLobby = () => {
   const emptySeats = Math.max(0, maxPlayers - players.length);
 
   return (
-    <div className="flex min-h-dvh w-full flex-col bg-ground font-game">
-      <div className="flex h-14 shrink-0 items-center justify-between px-4 md:px-6">
+    // h-full + overflow-y-auto (not min-h-dvh): this sits inside GameUI's
+    // overflow-hidden app frame, where a taller-than-viewport lobby was
+    // CLIPPED — on short viewports (150% OS zoom, half-tiled windows) the
+    // Ready/Start button rendered below the fold and could never be
+    // clicked. Scrolling the lobby itself makes every control reachable at
+    // any height; the svh-clamped rhythm below keeps common sizes from
+    // needing to scroll at all.
+    <div className="flex h-full w-full flex-col overflow-y-auto bg-ground font-game">
+      <div className="flex h-14 shrink-0 items-center justify-between px-4 md:px-6 short:h-12">
         <Link
           href="/"
           className="flex items-center gap-2 text-lg font-extrabold tracking-tight text-ink"
@@ -366,14 +373,18 @@ export const GameLobby = () => {
         </div>
       </div>
 
-      <main className="mx-auto flex w-full max-w-3xl flex-1 flex-col items-center justify-center px-4 pb-14 text-center">
+      {/* my-auto, not flex-1 justify-center: auto margins center the content
+          when there's room but degrade to normal flow when there isn't —
+          justify-center inside a scroller pushes the overflow off BOTH ends,
+          leaving the top unreachable. */}
+      <main className="mx-auto my-auto flex w-full max-w-3xl flex-col items-center px-4 pb-[clamp(1.5rem,5svh,3.5rem)] text-center">
         <p className="text-xs font-semibold uppercase tracking-widest text-ink-muted">
           Private table
         </p>
 
         <button
           onClick={copyInvite}
-          className="mt-3 rounded-card px-4 py-1 text-6xl font-extrabold tracking-[0.25em] text-ink tabular-nums transition-colors hover:text-ink/80 sm:text-7xl"
+          className="mt-3 rounded-card px-4 py-1 text-6xl font-extrabold tracking-[0.25em] text-ink tabular-nums transition-colors hover:text-ink/80 sm:text-7xl short:mt-2 short:text-5xl"
           aria-label="Copy invite link"
         >
           {gameId}
@@ -384,7 +395,7 @@ export const GameLobby = () => {
             : "Tap the code to copy an invite link"}
         </p>
 
-        <div className="mt-10 flex flex-wrap items-start justify-center gap-4 sm:gap-6">
+        <div className="mt-[clamp(1rem,4svh,2.5rem)] flex flex-wrap items-start justify-center gap-4 sm:gap-6">
           {players.map((p) => (
             <div
               key={p.id}
@@ -430,7 +441,7 @@ export const GameLobby = () => {
           ))}
         </div>
 
-        <p className="mt-8 text-sm font-semibold text-ink-muted">
+        <p className="mt-[clamp(0.75rem,3svh,2rem)] text-sm font-semibold text-ink-muted">
           {players.length} of {maxPlayers} seats filled
         </p>
         <p className="mt-1 h-5 text-sm text-ink-muted">{statusLine}</p>
@@ -438,7 +449,7 @@ export const GameLobby = () => {
         <button
           onClick={action.onClick}
           className={cn(
-            "mt-6 flex h-14 min-w-[12rem] items-center justify-center rounded-full px-8 text-base font-bold transition-colors sm:min-w-[16rem]",
+            "mt-[clamp(0.75rem,2.5svh,1.5rem)] flex h-14 min-w-[12rem] items-center justify-center rounded-full px-8 text-base font-bold transition-colors sm:min-w-[16rem] short:h-12",
             action.accent
               ? "bg-accent text-accent-ink hover:bg-accent/90"
               : "border border-hairline bg-surface-2 text-ink-muted hover:text-ink",
@@ -447,7 +458,7 @@ export const GameLobby = () => {
           {action.label}
         </button>
 
-        <p className="mt-10 text-sm text-ink-muted">
+        <p className="mt-[clamp(1rem,3.5svh,2.5rem)] text-sm text-ink-muted">
           New here?{" "}
           <button
             onClick={() => setLearnOpen(true)}

--- a/client/components/game/GameUI.tsx
+++ b/client/components/game/GameUI.tsx
@@ -13,6 +13,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import CardAnimationRoot from "@/components/cards/CardAnimationRoot";
 import { GameStage } from "shared-types";
 import { useGameSounds } from "@/components/game/useGameSounds";
+import { useServerKeepalive } from "@/hooks/use-server-keepalive";
 
 type GameView = "prompting" | "lobby" | "game" | "connecting";
 
@@ -34,6 +35,9 @@ export default function GameUI() {
   // Mounted here so the table's voice covers the lobby (joins, readies,
   // start) as well as the board.
   useGameSounds();
+  // Any open game page keeps the free-tier host from idling out under a
+  // waiting lobby (details in the hook).
+  useServerKeepalive();
 
   const renderContent = () => {
     switch (view) {

--- a/client/components/game/PlayerHand.tsx
+++ b/client/components/game/PlayerHand.tsx
@@ -195,7 +195,12 @@ const PlayerHand: React.FC<PlayerHandProps> = ({
     gameStage === GameStage.INITIAL_PEEK &&
     visibleCards.some((vc) => vc.source === "initial-peek");
 
-  const combinedClass = cn(isLocked && "opacity-60", dense && "gap-1");
+  const combinedClass = cn(
+    isLocked && "opacity-60",
+    // Regular grids give their row gap back first on short viewports; dense
+    // grids already sit at gap-1.
+    dense ? "gap-1" : "short:gap-1.5",
+  );
 
   return (
     <HandGrid numItems={handToDisplay.length} className={combinedClass}>
@@ -211,7 +216,7 @@ const PlayerHand: React.FC<PlayerHandProps> = ({
                 "relative aspect-[5/7]",
                 dense
                   ? "w-[min(8svh,11.5vw,3.5rem)] @4xl:w-[min(8svh,11.5vw)]"
-                  : "w-[min(8svh,15vw)]",
+                  : "w-(--card-w)",
               )}
             >
               <div className="absolute inset-0 rounded-card border border-hairline" />
@@ -288,15 +293,17 @@ const PlayerHand: React.FC<PlayerHandProps> = ({
             key={card.id}
             className={cn(
               "relative aspect-[5/7]",
-              // svh, not vh: stable while mobile browser chrome collapses.
-              // Dense cells trade size for fitting six seats on a phone —
-              // their taps are occasional (ability targeting), not constant.
-              // The 3.5rem cap is for mid-width portrait tablets; at @4xl a
-              // full row fits anyway and the cap lifts, so desktop and
-              // half-screen sizes are unchanged.
+              // Regular cells share the table-wide --card-w token (globals.css)
+              // with the center piles, so the whole table scales as one unit
+              // on height-starved viewports. Dense cells trade size for
+              // fitting six seats on a phone — their taps are occasional
+              // (ability targeting), not constant. The 3.5rem cap is for
+              // mid-width portrait tablets; at @4xl a full row fits anyway
+              // and the cap lifts, so desktop and half-screen sizes are
+              // unchanged.
               dense
                 ? "w-[min(8svh,11.5vw,3.5rem)] @4xl:w-[min(8svh,11.5vw)]"
-                : "w-[min(8svh,15vw)]",
+                : "w-(--card-w)",
             )}
           >
             {/* No whileHover here: this is the layoutId projection node, and

--- a/client/components/game/PlayerHandStrip.tsx
+++ b/client/components/game/PlayerHandStrip.tsx
@@ -184,7 +184,10 @@ const PlayerInfoBadge = ({
   }
 
   return (
-    <div className="flex flex-col items-center gap-2 font-game">
+    // Height-starved viewports flatten the stacked name/chip header into one
+    // row: the two-line header costs ~60px per seat, and with a hand above
+    // AND below the table that is exactly the overflow budget.
+    <div className="flex flex-col items-center gap-1.5 font-game short:flex-row">
       <h3 className="flex items-center gap-2 text-[clamp(1rem,2.5vw,1.125rem)] font-bold text-ink">
         {/* The one "whose turn" color on screen: an accent dot before the name. */}
         {isCurrentTurn && (
@@ -308,8 +311,10 @@ export const PlayerHandStrip: React.FC<PlayerHandStripProps> = ({
       }}
       animate={dqBeat ? { y: [0, 3, 0] } : { y: 0 }}
       className={cn(
-        "flex flex-col items-center",
-        compact ? "gap-1" : "gap-2",
+        // vshort: the seat header moves beside the hand — above it, its
+        // ~30px is the difference between the board fitting and scrolling.
+        "flex flex-col items-center vshort:flex-row",
+        compact ? "gap-1" : "gap-1.5 short:gap-1 vshort:gap-2",
       )}
     >
       <PlayerInfoBadge

--- a/client/components/game/TableArea.tsx
+++ b/client/components/game/TableArea.tsx
@@ -215,13 +215,13 @@ export const TableArea = ({
             faceDown
             canInteract={canDrawFromDeck}
             onClick={handleDeckClick}
-            className="w-[min(8vh,15vw)]"
+            className="w-(--card-w)"
           />
           {/* During DEALING every dealt card sits here with its layoutId, so
               when the hands render on the next stage each card flies from the
               deck to its grid slot instead of popping into place. */}
           {dealingDeck.length > 0 && (
-            <div className="absolute bottom-0 left-1/2 w-[min(8vh,15vw)] aspect-[5/7] -translate-x-1/2 pointer-events-none">
+            <div className="absolute bottom-0 left-1/2 w-(--card-w) aspect-[5/7] -translate-x-1/2 pointer-events-none">
               {dealingDeck.map((card) => (
                 <motion.div
                   key={card.id}
@@ -263,7 +263,7 @@ export const TableArea = ({
 
       {/* The drawn-card slot keeps its full size even while empty so the deck
           and discard piles don't shift sideways on every draw/discard. */}
-      <div className="relative w-[min(8vh,15vw)] aspect-[5/7]">
+      <div className="relative w-(--card-w) aspect-[5/7]">
         {/* Single-owner layoutId handoff — no entrance/exit poses here. On
             mount the card flies from the pile top that unmounted in the same
             commit; on unmount the hand cell or discard top picks the layoutId
@@ -296,7 +296,7 @@ export const TableArea = ({
             isMatchTarget={matchWindowOpen}
             canInteract={canDrawFromDiscard || canDiscardDrawnCard}
             onClick={handleDiscardClick}
-            className="w-[min(8vh,15vw)]"
+            className="w-(--card-w)"
           />
           {/* A match lands with one quiet accent beat at the point of impact
               (the PENALTY. stamp owns the failure case). */}

--- a/client/hooks/use-server-keepalive.ts
+++ b/client/hooks/use-server-keepalive.ts
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect } from "react";
+import { SERVER_URL } from "@/lib/socket";
+
+/** Render's free tier spins a service down after ~15 minutes without inbound
+ *  HTTP traffic — and frames on an already-open WebSocket don't reliably
+ *  count, so a lobby full of connected-but-waiting players could have the
+ *  server yanked out from under it. While a game page is open, GET /health
+ *  (which exists for exactly this: server/src/index.ts) on a cadence well
+ *  inside that window so the platform always sees live traffic.
+ *
+ *  4 minutes also stays inside Chrome's once-per-minute background-tab timer
+ *  throttle (pages holding an open socket are exempt from the harsher
+ *  once-per-hour tier), so a backgrounded lobby tab keeps the server warm
+ *  too. no-cors: the response body is irrelevant, reaching the server is the
+ *  point — this keeps cross-origin console noise out even if CORS headers
+ *  ever drift. */
+const KEEPALIVE_INTERVAL_MS = 4 * 60 * 1000;
+
+export function useServerKeepalive() {
+  useEffect(() => {
+    const ping = () => {
+      fetch(`${SERVER_URL}/health`, {
+        mode: "no-cors",
+        cache: "no-store",
+      }).catch(() => {
+        // Offline / server asleep: nothing to do — the socket layer owns
+        // reconnection and its own user-facing status.
+      });
+    };
+    const id = setInterval(ping, KEEPALIVE_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, []);
+}

--- a/client/lib/socket.ts
+++ b/client/lib/socket.ts
@@ -6,7 +6,9 @@ import {
 } from "shared-types";
 import logger from "./logger";
 
-const URL = process.env.NEXT_PUBLIC_WEBSOCKET_URL || "http://localhost:8000";
+export const SERVER_URL =
+  process.env.NEXT_PUBLIC_WEBSOCKET_URL || "http://localhost:8000";
+const URL = SERVER_URL;
 
 logger.info({ socketUrl: URL }, "Initializing Socket.IO client");
 


### PR DESCRIPTION
The app frame is h-dvh + overflow-hidden, so any content taller than the viewport was silently clipped: on half-tiled 1080p windows the action-bar prompt sank below the fold, and on 150%-zoom laptops the lobby's Ready/Start button rendered off-screen and could never be clicked.

Board: the fixed chrome (header, seat headers, paddings, action row) now compresses continuously with viewport height via clamp(...svh...) and two height variants — short (<=960px) flattens the stacked seat header into one line, vshort (<=680px) moves it beside the hand where width is abundant. All table cards share one --card-w token so hands and piles scale together, and the board grid gets overflow-y-auto as a last-resort so nothing is ever unreachable. The action bar now fills its fixed grid row and lets the prompt slot flex, instead of tracking the row height with a second clamp that drifted a few px past it (the phantom scrollbar).

Lobby: scrolls itself when it must (my-auto centering keeps the top reachable, unlike justify-center) and tightens its vertical rhythm with the same svh clamps, so common sizes never need to scroll at all.

Verified with a scripted two-player game (create/join/ready/deal/peek/ play) measuring overflow and button reachability at 1920x944, 945x830, 945x750, 1366x625, 1280x600, 960x500 and 390x740: no overflow anywhere, every control directly visible.

Also: ping the server's /health every 4 minutes from any open game page so free-tier hosting (Render spins down after ~15 idle minutes; open sockets don't reliably count) can't yank the server out from under a waiting lobby. The app-side grace timers already handle everything else.