### PR TITLE
Turn the linter back on and clear what it reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,13 @@ jobs:
       - name: Typecheck client
         run: npx tsc --noEmit -p client/tsconfig.json
 
+      # A step of its own rather than letting the client build lint, which is
+      # how it was switched off for the life of the project: the build carries
+      # --no-lint, and Next 16 drops build time linting altogether. This calls
+      # the ESLint CLI, which outlives both.
+      - name: Lint client
+        run: npm run lint
+
       - name: Build server
         run: npm run build:server
 

--- a/client/app/layout.tsx
+++ b/client/app/layout.tsx
@@ -2,7 +2,6 @@ import "./globals.css";
 import type { Metadata } from "next";
 import { Nunito_Sans } from "next/font/google";
 import { Providers } from "./providers";
-import { cn } from "@/lib/utils";
 import "lenis/dist/lenis.css";
 
 // The one type family, app-wide (exposed as --font-game). The landing page

--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -19,7 +19,6 @@ import { ThemeToggle } from "@/components/ui/ThemeToggle";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
 import { Users, ArrowRight, Menu, X } from "lucide-react";
-import { FaGithub, FaSpotify } from "react-icons/fa";
 import { BrandMark } from "@/components/ui/BrandMark";
 import { HeroCards } from "@/components/ui/HeroCards";
 import { Signature, secondSignature } from "@/components/ui/Signature";
@@ -240,7 +239,7 @@ function HomePage() {
         className="fixed top-0 z-50 w-full border-b border-hairline bg-ground"
       >
         <div className="mx-auto flex h-16 w-full max-w-6xl items-center justify-between px-5 sm:px-8">
-          <a
+          <Link
             href="/"
             onClick={(e) => {
               e.preventDefault();
@@ -252,7 +251,7 @@ function HomePage() {
             <span className="text-2xl font-extrabold tracking-tight text-ink">
               Check
             </span>
-          </a>
+          </Link>
 
           <nav className="hidden items-center gap-8 lg:flex">
             {NAV_ITEMS.map((item) => (

--- a/client/app/providers.tsx
+++ b/client/app/providers.tsx
@@ -17,10 +17,24 @@ import { useEffect, useRef } from "react";
 import { createActor } from "xstate";
 import {
   SocketEventName,
+  type Card,
+  type ChatMessage,
   type ClientCheckGameState,
-  type PlayerActionType,
+  type ClientToServerEvents,
+  type RichGameLogMessage,
+  type ServerToClientEvents,
 } from "shared-types";
 import { DeviceProvider } from "@/context/DeviceContext";
+
+// The socket contract in shared-types already describes every payload these
+// bridges carry. Deriving the handler types from it means a change on the
+// server side surfaces here as a type error instead of being absorbed.
+type PlayerActionPayload = Parameters<
+  ClientToServerEvents[SocketEventName.PLAYER_ACTION]
+>[0];
+type AbilityPeekResultPayload = Parameters<
+  ServerToClientEvents[SocketEventName.ABILITY_PEEK_RESULT]
+>[0];
 
 // ============================================================================
 //  EFFECTS BRIDGE COMPONENT – connects the actor to sockets and routing
@@ -34,10 +48,7 @@ function UIMachineEffects({ actor }: { actor: UIMachineActorRef }) {
     const socketSub = actor.on("EMIT_TO_SOCKET", (emitted: EmittedEvent) => {
       if (emitted.type !== "EMIT_TO_SOCKET") return;
       if (emitted.eventName === SocketEventName.PLAYER_ACTION) {
-        socket.emit(
-          emitted.eventName,
-          emitted.payload as { type: PlayerActionType; payload?: any },
-        );
+        socket.emit(emitted.eventName, emitted.payload as PlayerActionPayload);
       } else {
         logger.warn(
           { event: emitted },
@@ -54,21 +65,22 @@ function UIMachineEffects({ actor }: { actor: UIMachineActorRef }) {
     // Socket → Actor bridges
     const gs = (g: ClientCheckGameState) =>
       actor.send({ type: "CLIENT_GAME_STATE_UPDATED", gameState: g });
-    const lg = (m: any) => actor.send({ type: "NEW_GAME_LOG", logMessage: m });
-    const cm = (m: any) =>
+    const lg = (m: RichGameLogMessage) =>
+      actor.send({ type: "NEW_GAME_LOG", logMessage: m });
+    const cm = (m: ChatMessage) =>
       actor.send({ type: "NEW_CHAT_MESSAGE", chatMessage: m });
-    const pk = (d: { hand: any[] }) =>
+    const pk = (d: { hand: Card[] }) =>
       actor.send({ type: "INITIAL_PEEK_INFO", hand: d.hand });
-    const pr = (d: { results: any[] }) =>
+    const pr = (d: AbilityPeekResultPayload) =>
       actor.send({ type: "ABILITY_PEEK_RESULT", results: d.results });
     const er = (e: { message: string }) =>
       actor.send({ type: "ERROR_RECEIVED", error: e.message });
-    const ce = (err: any) =>
+    const ce = (err: Error) =>
       logger.warn(
         { error: err?.message ?? "connection error" },
         "Socket connection error",
       );
-    const il = (l: any[]) =>
+    const il = (l: RichGameLogMessage[]) =>
       actor.send({ type: "INITIAL_LOGS_RECEIVED", logs: l });
     const onConnect = () =>
       actor.send({
@@ -125,7 +137,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
 
   if (actorRef.current === null) {
     const getInitialInput = (): UIMachineInput => {
-      let initial: UIMachineInput = {};
+      const initial: UIMachineInput = {};
 
       // Capture gameId from URL when landing directly on game page
       if (pathname.startsWith("/game/")) {

--- a/client/components/cards/VisualCardStack.tsx
+++ b/client/components/cards/VisualCardStack.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useEffect, useRef, useState } from "react";
-import { type Card, PublicCard } from "shared-types";
+import { PublicCard } from "shared-types";
 import { PlayingCard } from "./PlayingCard";
 import { cn } from "@/lib/utils";
 import { AnimatePresence, motion } from "framer-motion";

--- a/client/components/game/ActionController.tsx
+++ b/client/components/game/ActionController.tsx
@@ -115,10 +115,9 @@ const selectActionControllerProps = (state: UIMachineSnapshot) => {
       topDiscardCard.rank,
     );
 
-  // Type of deep state path is not covered by xstate typing; cast for compile.
   const isViewingPeek = state.matches({
     inGame: { ability: { resolving: "viewingPeek" } },
-  } as any);
+  });
 
   const isAbilitySelecting =
     !!currentAbilityContext &&
@@ -299,7 +298,6 @@ export const ActionController: React.FC<{ children?: React.ReactNode }> = ({
 
     if (abilityContext && isAbilityPlayer && isAbilitySelecting) {
       const {
-        type,
         stage,
         sourceCard,
         selectedPeekTargets,
@@ -469,7 +467,6 @@ export const ActionController: React.FC<{ children?: React.ReactNode }> = ({
     if (abilityContext && isAbilityPlayer && isAbilitySelecting) {
       const {
         stage,
-        type,
         selectedPeekTargets,
         maxPeekTargets,
         selectedSwapTargets,

--- a/client/components/game/ActionControllerView.tsx
+++ b/client/components/game/ActionControllerView.tsx
@@ -2,7 +2,6 @@
 
 import React from "react";
 import ActionBarComponent from "./ActionBarComponent";
-import { useActionController } from "./ActionController";
 
 /**
  * This component is responsible for rendering the UI of the action bar.

--- a/client/components/game/ActionFactories.tsx
+++ b/client/components/game/ActionFactories.tsx
@@ -90,7 +90,6 @@ export const createPassMatchAction = (
 export const createAttemptMatchAction = (
   onClick: () => void,
   disabled?: boolean,
-  _hasSelection: boolean = false,
 ): Action => ({
   label: "Confirm Match",
   variant: "primary",

--- a/client/components/game/PlayerHand.tsx
+++ b/client/components/game/PlayerHand.tsx
@@ -195,7 +195,7 @@ const PlayerHand: React.FC<PlayerHandProps> = ({
     gameStage === GameStage.INITIAL_PEEK &&
     visibleCards.some((vc) => vc.source === "initial-peek");
 
-  const combinedClass = cn(isLocked && "opacity-60", dense && "gap-1");
+  const combinedClass = cn(isLocked && "opacity-60", dense && "gap-1", className);
 
   return (
     <HandGrid numItems={handToDisplay.length} className={combinedClass}>

--- a/client/components/game/RoundSummary.tsx
+++ b/client/components/game/RoundSummary.tsx
@@ -4,7 +4,11 @@ import React from "react";
 import { motion, useReducedMotion } from "framer-motion";
 import { Crown } from "lucide-react";
 import { type Player, PlayerStatus } from "shared-types";
-import { useUIActorRef, useUISelector } from "@/context/GameUIContext";
+import {
+  useUIActorRef,
+  useUISelector,
+  type UIMachineSnapshot,
+} from "@/context/GameUIContext";
 import { cn } from "@/lib/utils";
 import { play } from "@/lib/sounds";
 
@@ -22,16 +26,16 @@ interface RoundSummaryProps {
   onToggleChat: () => void;
 }
 
-const selectIsGameMaster = (state: any) =>
+const selectIsGameMaster = (state: UIMachineSnapshot) =>
   state.context.currentGameState?.gameMasterId === state.context.localPlayerId;
 
-const selectGameMasterId = (state: any) =>
+const selectGameMasterId = (state: UIMachineSnapshot) =>
   state.context.currentGameState?.gameMasterId ?? null;
 
-const selectCheckCallerId = (state: any) =>
+const selectCheckCallerId = (state: UIMachineSnapshot) =>
   state.context.currentGameState?.checkDetails?.callerId ?? null;
 
-const selectRoundEpoch = (state: any) =>
+const selectRoundEpoch = (state: UIMachineSnapshot) =>
   state.context.currentGameState?.roundEpoch ?? 0;
 
 // The table ripple upstairs runs ~1.5s after the panel mounts (PlayerHand's

--- a/client/components/modals/JoinGameModal.tsx
+++ b/client/components/modals/JoinGameModal.tsx
@@ -145,7 +145,7 @@ export function JoinGameModal({
                   className="mt-2 h-12 w-full rounded-full border border-hairline bg-surface px-5 text-center text-lg font-bold uppercase tracking-[0.3em] text-ink outline-none transition-colors placeholder:font-normal placeholder:tracking-normal placeholder:text-ink-muted focus:border-accent"
                 />
                 <p className="mt-2 text-xs text-ink-muted">
-                  Five characters, shown big in the host's lobby.
+                  Five characters, shown big in the host&apos;s lobby.
                 </p>
               </motion.div>
             )}

--- a/client/eslint.config.mjs
+++ b/client/eslint.config.mjs
@@ -10,6 +10,13 @@ const compat = new FlatCompat({
 });
 
 const eslintConfig = [
+  {
+    // `next lint` applied these implicitly. The ESLint CLI does not, and it is
+    // the only entry point left once Next 16 removes `next lint`, so the scope
+    // has to be stated here. Without it a run walks the build output and
+    // reports about 15,000 problems, none of them ours.
+    ignores: ["**/node_modules/**", ".next/**", "out/**", "next-env.d.ts"],
+  },
   ...compat.extends("next/core-web-vitals", "next/typescript"),
 ];
 

--- a/client/machines/uiMachine.ts
+++ b/client/machines/uiMachine.ts
@@ -15,18 +15,15 @@ import {
   GameStage,
   type ClientAbilityContext,
   type PlayerId,
-  type GameId,
   type ClientCheckGameState,
   type CreateGameResponse,
   type JoinGameResponse,
-  type AttemptRejoinResponse,
   type ChatMessage,
   type RichGameLogMessage,
   type Card,
   type AbilityActionPayload,
   type PeekTarget,
   type SwapTarget,
-  type AbilityType,
   TurnPhase,
 } from "shared-types";
 import { toast } from "sonner";
@@ -50,7 +47,7 @@ type ServerToClientEvents =
 
 type SocketEmitEvent = {
   eventName: SocketEventName.PLAYER_ACTION;
-  payload: { type: PlayerActionType | string; payload?: any };
+  payload: { type: PlayerActionType | string; payload?: unknown };
 };
 
 type EmittedEventToSocket = { type: "EMIT_TO_SOCKET" } & SocketEmitEvent;
@@ -354,7 +351,10 @@ export const uiMachine = setup({
       } as const;
     }),
     emitPlayerAction: emit(({ event }) => {
-      const { type, ...rest } = event as any;
+      const { type, ...rest } = event as { type: string } & Record<
+        string,
+        unknown
+      >;
       return {
         type: "EMIT_TO_SOCKET",
         eventName: SocketEventName.PLAYER_ACTION,

--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,7 @@
     "build": "next build --no-lint",
     "postinstall": "npm run build -w shared-types",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "eslint ."
   },
   "dependencies": {
     "@georgedoescode/spline": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "build:server": "npm run build -w server",
     "build:client": "npm run build -w client",
     "build:shared": "npm run build -w shared-types",
+    "lint": "npm run lint -w client",
     "start:server": "npm start -w server",
     "start:client": "npm start -w client",
     "dev:client": "npm run dev -w client",


### PR DESCRIPTION
Closes #55.

ESLint was configured at `client/eslint.config.mjs` and never run: `build:client` carries `--no-lint` and CI never called it. Measured today it reported **15 errors and 9 warnings across 11 files**, matching the issue.

## Fixes, against the real types

Nothing was silenced to bring the count down.

- **`providers.tsx`** held 7 of the `any`s. The socket is already typed `Socket<ServerToClientEvents, ClientToServerEvents>`, so every payload shape was one import away. The bridges now derive their types from that contract, which means a change on the server side lands here as a type error instead of being absorbed.
- **`RoundSummary.tsx`** selectors now take `UIMachineSnapshot`, the type every other selector in the codebase already uses.
- **`PlayerHand.tsx`** accepted a `className` prop and dropped it on the floor. It now reaches `combinedClass`. No caller passes one today, so this changes nothing on screen and stops the prop lying.
- **`ActionController.tsx`** carried `as any` with a comment saying xstate could not type the deep state path. It can: the cast and the comment are gone and the client typechecks.
- **`page.tsx`** header brand is a `<Link>`. It keeps the existing `preventDefault` and `window.location.reload()`, so the click still hard reloads rather than client navigating.
- The rest are unused imports and discarded destructured bindings.

## Two things the old setup was hiding

**`next lint` never looked at `machines/uiMachine.ts`.** It only walks the default app directories. That file held 2 more errors and 3 unused type imports that no one had ever seen. Fixed here too.

**The bare ESLint CLI reported about 15,000 problems.** The flat config declares no `ignores`, so a plain `eslint .` walks `.next` and the build output. `next lint` applied those ignores implicitly. Since `next lint` is deprecated and removed in Next 16, the config now states its own scope.

## Keeping it on

`lint` now calls the ESLint CLI rather than `next lint`, and CI runs it as a step of its own. Doing it that way, rather than dropping `--no-lint`, means the gate survives Next 16 removing build time linting, and the client build is not linted twice.

## Verification

- `npx eslint .` exits 0, no output.
- `npx tsc --noEmit -p client/tsconfig.json` passes.
- `npm run build:client` succeeds, all 6 routes generated.
- Prettier status is unchanged: the same 6 of the touched files were already unformatted before and after, so this adds no formatting debt ahead of #58.

Not verified in a browser. The two changes with any visible surface are the brand link and the `PlayerHand` className, and both are argued above as behaviour preserving rather than tested as such.
