### PR TITLE
Stop the client build dying on Next 16

### DIFF
--- a/client/next.config.ts
+++ b/client/next.config.ts
@@ -4,6 +4,10 @@ import path from "path";
 const nextConfig: NextConfig = {
   transpilePackages: ["shared-types"],
 
+  // Not an oversight: lint runs as its own CI step, so the build does not
+  // repeat it.
+  eslint: { ignoreDuringBuilds: true },
+
   turbopack: {
     resolveAlias: {
       "@": "./",

--- a/client/package.json
+++ b/client/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build --no-lint",
+    "build": "next build",
     "postinstall": "npm run build -w shared-types",
     "start": "next start",
     "lint": "eslint ."


### PR DESCRIPTION
`next build --no-lint` is a hard error on Next 16: `unknown option '--no-lint'`. It surfaced in #65, Dependabot's sharp security update, which pulls Next 16 in as an ancestor dependency and dies on this line before reaching anything interesting.

Replaced with `eslint: { ignoreDuringBuilds: true }` in `next.config.ts`. Same effect, it is the documented way to express it, and if a future Next stops recognising the option it degrades to a warning rather than failing the build. A CLI flag that no longer exists cannot do that.

Lint is unaffected. It has been its own CI step since b6dd7ec, so the build was never what enforced it. This only removes a flag that was already redundant and was going to break the first time anyone tried a Next major.

## Verification

`npm run build:client` compiles and still reports `Skipping linting`, so behaviour is unchanged on Next 15. `npm run lint` and `npm run format:check` both clean.