### PR TITLE
Make the lobby reachable on short viewports

### DIFF
--- a/client/components/game/GameLobby.tsx
+++ b/client/components/game/GameLobby.tsx
@@ -331,7 +331,7 @@ export const GameLobby = () => {
   const emptySeats = Math.max(0, maxPlayers - players.length);
 
   return (
-    <div className="flex min-h-dvh w-full flex-col bg-ground font-game">
+    <div className="flex h-full w-full flex-col overflow-y-auto bg-ground font-game">
       <div className="flex h-14 shrink-0 items-center justify-between px-4 md:px-6">
         <Link
           href="/"
@@ -362,7 +362,10 @@ export const GameLobby = () => {
         </div>
       </div>
 
-      <main className="mx-auto flex w-full max-w-3xl flex-1 flex-col items-center justify-center px-4 pb-14 text-center">
+      {/* Centred with auto margins rather than justify-center. Both centre
+          when there is room, but justify-center puts the overflow past the top
+          edge, where scrolling cannot reach it. */}
+      <main className="mx-auto my-auto flex w-full max-w-3xl flex-col items-center px-4 pb-14 text-center">
         <p className="text-xs font-semibold uppercase tracking-widest text-ink-muted">
           Private table
         </p>


### PR DESCRIPTION
Fixes #35.

## What was wrong

Three things stacked, and only fixing all of them works.

1. `GameUI.tsx:50` wraps every view in `h-screen overflow-hidden`. A fixed frame that never scrolls. Shared with the board, so untouched here, as the issue requires.
2. `GameLobby.tsx` sized its root with `min-h-dvh`, so on a short viewport it grew *past* that frame and the overflow was silently clipped. Nothing anywhere could scroll.
3. Its `<main>` centred with `flex-1 justify-center`.

That third point is the trap. `justify-content: center` distributes overflow past **both** edges, and content pushed past the top edge cannot be scrolled back to, because scroll position cannot go negative. Fixing only the scrolling would have traded an unreachable Ready button for an unreachable invite code.

## The fix

Both lines are in the lobby. Nothing outside it changes.

- Root: `min-h-dvh` becomes `h-full` with `overflow-y-auto`, so the lobby fills the frame and scrolls inside it.
- `<main>`: `flex-1 ... justify-center` becomes `my-auto`. Auto margins centre the same way when there is spare room and collapse to `0` when there is not, so nothing lands out of reach.

## Verification

Driven in a real browser, six seats, since a type check cannot see a layout bug. Both states measured at the same viewport.

**At 1280x500, before:**

| | |
| --- | --- |
| `overflow-y` | `visible` |
| `scrollHeight` / `clientHeight` | 902 / 902 |
| max `scrollTop` reachable | **0** |
| Ready button | y=730, **unreachable** |

The lobby rendered 902px tall inside a 500px frame. 402px, including the only control that starts the game, clipped with no way to reach it.

**At 1280x500, after:**

| | |
| --- | --- |
| `overflow-y` | `auto` |
| `scrollHeight` / `clientHeight` | 902 / 500 |
| max `scrollTop` reachable | 402 |
| Ready button at full scroll | y=328, **visible** |
| `document.elementFromPoint` on its centre | resolves to the button, so a click lands |

Invite code still reachable at `scrollTop: 0`, which is the regression the `my-auto` change exists to prevent.

**Unchanged at normal sizes**, which is the other half of the issue. At 1280x1200 the `<main>` box changes shape, since it no longer stretches, but the rendered content does not move: the invite code sits at **y=233 both before and after**, and neither version scrolls.

Also `npx tsc --noEmit -p client/tsconfig.json`, `npm run lint` and `npm run format:check` all clean.

Screenshots of both states exist but `gh` cannot upload images, so the measurements above are the record.