### PR TITLE
Guard against surprise dependency majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,10 @@ updates:
           - patch
     # Majors are excluded on purpose, not by oversight. With no test suite
     # (#36), a green build is not evidence a breaking release is safe.
+    #
+    # This is not a guarantee. Security updates ignore these rules, so a major
+    # can still arrive as one. scripts/check-dependency-majors.mjs is what
+    # actually catches it.
     ignore:
       - dependency-name: "*"
         update-types:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,10 @@ jobs:
           node-version: 22
           cache: npm
 
+      # Before install, so a surprise major fails in seconds.
+      - name: Check dependency majors
+        run: npm run check:majors
+
       - name: Install
         run: npm ci
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "build:client": "npm run build -w client",
     "build:shared": "npm run build -w shared-types",
     "lint": "npm run lint -w client",
+    "check:majors": "node scripts/check-dependency-majors.mjs",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "start:server": "npm start -w server",

--- a/scripts/check-dependency-majors.mjs
+++ b/scripts/check-dependency-majors.mjs
@@ -1,0 +1,71 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+// Dependabot's ignore rules do not apply to security updates, so a major can
+// arrive as a security fix. #65 was next 15 to 16 wearing a sharp patch's
+// clothes. Nothing else in CI would notice: a major that still compiles and
+// still boots passes every other step.
+//
+// Dependabot edits manifests, never this file, so a major bump fails here
+// until a person deliberately changes the number and says why.
+const EXPECTED = {
+  "client/package.json": {
+    next: 15,
+    react: 19,
+    "react-dom": 19,
+    xstate: 5,
+    "@xstate/react": 5,
+    "socket.io-client": 4,
+    motion: 12,
+  },
+  "server/package.json": {
+    "socket.io": 4,
+    xstate: 5,
+    immer: 10,
+  },
+};
+
+const majorOf = (range) => {
+  const match = /(\d+)\./.exec(String(range).replace(/^[^\d]*/, ""));
+  return match ? Number(match[1]) : null;
+};
+
+const problems = [];
+
+for (const [manifest, expected] of Object.entries(EXPECTED)) {
+  const pkg = JSON.parse(readFileSync(join(root, manifest), "utf8"));
+  const deps = { ...pkg.dependencies, ...pkg.devDependencies };
+
+  for (const [name, wanted] of Object.entries(expected)) {
+    const declared = deps[name];
+    if (!declared) {
+      problems.push(`${manifest}: ${name} is no longer a dependency`);
+      continue;
+    }
+    const found = majorOf(declared);
+    if (found !== wanted) {
+      problems.push(
+        `${manifest}: ${name} is on major ${found} (${declared}), expected ${wanted}`,
+      );
+    }
+  }
+}
+
+if (problems.length > 0) {
+  console.error("Guarded dependency majors moved:\n");
+  for (const p of problems) console.error(`  ${p}`);
+  console.error(`
+A major version of one of these changes behaviour that type checking and a
+successful build cannot see, and there is no test suite to catch it (#36).
+
+If the bump is wanted, migrate deliberately, then update EXPECTED in
+scripts/check-dependency-majors.mjs in the same pull request.`);
+  process.exit(1);
+}
+
+console.log(
+  `Guarded dependency majors unchanged (${Object.values(EXPECTED).reduce((n, e) => n + Object.keys(e).length, 0)} packages checked).`,
+);


### PR DESCRIPTION
The `no majors` rule in `.github/dependabot.yml` is not the guarantee it reads as, and nothing was left enforcing it.

## The gap

**Dependabot ignore rules do not apply to security updates.** #65 is the proof: next 15.5.23 to **16.3.1**, a framework major, arriving as an ancestor dependency of a sharp security patch. The ignore rule did not stop it, and both `dependabot.yml` and `CLAUDE.md` described majors as excluded, so a reader would reasonably believe it could not happen.

**What actually stopped #65 was an accident.** It died on `next build --no-lint`, a stale flag Next 16 rejects outright. 27f65ba has since removed that flag, correctly, since depending on an accident is worse than having no guard. But that leaves nothing.

Consider what the current pipeline would say about a framework major that compiles: three type checks pass, lint passes, format passes, the server builds, the boot probe answers `/health`, the client builds. All green. There is no test suite behind any of it (#36), so nothing in CI can see behaviour change. It would look mergeable.

## The guard

`scripts/check-dependency-majors.mjs` holds the expected major for the ten packages whose behaviour the game rests on and nothing else would catch:

`next`, `react`, `react-dom`, `xstate`, `@xstate/react`, `socket.io`, `socket.io-client`, `motion`, `immer`.

The trick is where the expectation lives. Dependabot edits manifests; it does not edit this script. So a major bump puts the manifest and the script into disagreement, CI fails, and the number only moves when a person changes it in a pull request that does the migration.

It runs **before `npm ci`**, so a surprise major costs seconds rather than a full build.

## Verification

Both directions, because a guard that cannot fail is not a guard.

**Passes on main:**

```
Guarded dependency majors unchanged (10 packages checked).
exit=0
```

**Fails on #65 recreated**, setting `next` to `16.3.1`:

```
Guarded dependency majors moved:

  client/package.json: next is on major 16 (16.3.1), expected 15
...
exit=1
```

The message names the package, both versions, and what to do about it.

`npm run format:check`, `npm run lint` and the client type check all clean.

## Also

`dependabot.yml` and `CLAUDE.md` both now say what is actually true: the ignore rule covers routine updates, security updates bypass it, and this script is the real gate.

This does not stop security majors reaching you, which would be the wrong outcome. You still get the pull request. It stops one landing quietly.