### PR TITLE
Collapse the verification gate into one command

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,13 +11,7 @@ Fixes #
 <!-- What you actually ran and looked at. There is no automated test suite yet, so this section is the verification.
 
 What CI will run, so you can fail it locally first:
-  npm run check:majors
-  npx tsc --noEmit -p shared-types/tsconfig.json
-  npx tsc --noEmit -p server/tsconfig.json
-  npx tsc --noEmit -p client/tsconfig.json
-  npm run lint
-  npm run format:check
-  npm run build:client
+  npm run verify
 
 If you touched game rules, say which rule you played through and with how many players. -->
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,27 +36,10 @@ jobs:
       - name: Install
         run: npm ci
 
-      - name: Build shared types
-        run: npm run build:shared
-
-      - name: Typecheck shared types
-        run: npx tsc --noEmit -p shared-types/tsconfig.json
-
-      - name: Typecheck server
-        run: npx tsc --noEmit -p server/tsconfig.json
-
-      - name: Typecheck client
-        run: npx tsc --noEmit -p client/tsconfig.json
-
-      # Its own step: the client build runs with --no-lint.
-      - name: Lint client
-        run: npm run lint
-
-      - name: Check formatting
-        run: npm run format:check
-
-      - name: Build server
-        run: npm run build:server
+      # One command, so this and what contributors are told to run cannot
+      # drift apart. Add a check to the verify script, not to this file.
+      - name: Verify
+        run: npm run verify
 
       # Typechecking proves the server compiles, not that it runs. This catches
       # a throw on startup or a broken module-alias mapping.
@@ -79,6 +62,3 @@ jobs:
           EOF
           kill $pid 2>/dev/null || true
           exit 1
-
-      - name: Build client
-        run: npm run build:client

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,16 +66,12 @@ There is no automated test suite yet, tracked in #36. Until there is, verificati
 Everything CI runs has to pass, and you can run all of it locally first:
 
 ```
-npm run check:majors
-npx tsc --noEmit -p shared-types/tsconfig.json
-npx tsc --noEmit -p server/tsconfig.json
-npx tsc --noEmit -p client/tsconfig.json
-npm run lint
-npm run format:check
-npm run build:client
+npm run verify
 ```
 
-`check:majors` fails if a guarded package changed major version. If that is deliberate, do the migration and update the expectation in `scripts/check-dependency-majors.mjs` in the same pull request.
+That is the same command CI runs, so if it passes locally it passes there. It checks guarded dependency majors, builds the shared types, type checks all three packages, lints, checks formatting, and builds the server and the client.
+
+Two notes on what it can tell you. If `check:majors` fails, a guarded package changed major version: do the migration deliberately and update the expectation in `scripts/check-dependency-majors.mjs` in the same pull request. And CI does one thing `verify` does not, starting the built server and waiting for it to answer `/health`, which catches a throw on startup that type checking cannot.
 
 CI also starts the built server and waits for it to answer `/health`, which catches a throw on startup that type checking cannot.
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "build:shared": "npm run build -w shared-types",
     "lint": "npm run lint -w client",
     "check:majors": "node scripts/check-dependency-majors.mjs",
+    "typecheck": "tsc --noEmit -p shared-types/tsconfig.json && tsc --noEmit -p server/tsconfig.json && tsc --noEmit -p client/tsconfig.json",
+    "verify": "npm run check:majors && npm run build:shared && npm run typecheck && npm run lint && npm run format:check && npm run build:server && npm run build:client",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "start:server": "npm start -w server",


### PR DESCRIPTION
Fixes the reason things kept going stale.

## The problem

What CI runs was written out in **four** places:

| File | Role |
| --- | --- |
| `.github/workflows/ci.yml` | the truth |
| `CONTRIBUTING.md` | a copy |
| `.github/PULL_REQUEST_TEMPLATE.md` | a copy |
| `CLAUDE.md` | a copy |

Every time CI gained a step, three copies rotted instantly. That happened **three times today**, once each for `lint`, `format:check` and `check:majors`. Each time the copies got fixed, then the next step landed and they were wrong again. That is not bad luck, it is duplication doing what duplication does.

## The change

`npm run verify` is now the gate. CI calls it rather than restating it, and the three documents name the command instead of listing its contents. They cannot drift, because there is nothing left in them to drift from. Adding a check means editing one file.

```
npm run verify
```

Runs `check:majors`, `build:shared`, `typecheck`, `lint`, `format:check`, `build:server`, `build:client`.

Also adds `npm run typecheck`, all three projects in one command, which is worth having when the full gate is too slow to sit through.

## What CI still owns

Two steps stay in the workflow because they cannot live in an npm script:

- **`check:majors` before `npm ci`**, so a surprise major fails in seconds instead of after an install. It runs again inside `verify`, which costs about 50ms and keeps `verify` complete for local use.
- **The server boot probe**, which needs a backgrounded process and a curl loop.

## Verification

Both directions, since a gate that cannot fail is not a gate.

**Passes:** `npm run verify` exits 0 on a clean tree and runs all the way through to the client build, 6 routes generated.

**Fails:** with `next` set to `16.3.1`, it exits 1 at the first check and never reaches a build:

```
Guarded dependency majors moved:
  client/package.json: next is on major 16 (16.3.1), expected 15
=== VERIFY EXIT: 1 ===
```