### PR TITLE
Make the game board reachable on short viewports

### DIFF
--- a/client/components/game/GameBoard.tsx
+++ b/client/components/game/GameBoard.tsx
@@ -212,7 +212,7 @@ export function GameBoard() {
   };
 
   return (
-    <div className="relative h-screen w-full bg-ground flex flex-col overflow-hidden @container font-game">
+    <div className="relative h-screen w-full bg-ground flex flex-col overflow-y-auto @container font-game">
       <GameHeader />
       {/* CHECK's recede is momentary and returns to identity. A HELD scale
           here (the R12 end-of-round recede) made every layout-projected card


### PR DESCRIPTION
Fixes #77. Same class as #35, this time on the board.

## What was wrong

`GameBoard.tsx` sized itself `h-screen` with `overflow-hidden`, so anything taller than the frame was clipped with **no way to scroll to it**.

Measured mid game at 1280x500 with two real clients:

| | |
| --- | --- |
| board content | **742px** |
| frame | 500px |
| past the fold | **242px** |
| `Hold to Check` button | **y=623**, unreachable |

That is not a cosmetic clip. The button that ends the round sat 123px below the fold with no scrollbar and no wheel scrolling, so a player in that window could not call check at all.

**Not only an extreme case.** At a normal 1280x900 viewport the same game still overflowed by **66px**.

## The change

One property. `overflow-hidden` becomes `overflow-y-auto`.

The grid, the `grid-rows-[auto_auto_1fr_auto_auto]` template, card sizing, the action bar and seat placement are all untouched. PR #34 bundled this problem with a board wide rewrite, broke the game and was rolled back twice, so this is deliberately the narrow version of the fix that worked for the lobby.

**One thing the lobby needed that the board does not.** #35 also had to move centring off `justify-center`, because that pushes overflow past the *top* edge where scroll position cannot reach it. The board places its rows from the start of a grid rather than centring them in a flex column, so it has no unreachable top.

## Verification

Driven in a real browser with **two clients through a dealt game**, not a mock. Two tabs, separate sessions, joined, readied, started, cards dealt.

**Before**, at 1280x500:

```
overflow-y: hidden
scrollHeight 742 / clientHeight 500
Hold to Check at y=623, visible: false, click lands: false
```

**After**, same viewport:

```
overflow-y: auto
scrollHeight 742 / clientHeight 500, scrolls 242
Hold to Check at y=381, visible: true
document.elementFromPoint on its centre resolves to the button
```

**Unchanged when it fits.** At 1280x1100 `scrollHeight === clientHeight === 1100`, no scroll, no scrollbar.

Worth noting one detail found while measuring: `overflow: hidden` still permits *programmatic* scrolling, so `scrollTop` is not the discriminator between the two states. The computed style is. That also means the known side panel jolt, where focusing the chat input scrolls the board, was leaving the board stuck at an offset the player could not scroll back from. This makes that recoverable.

`npm run verify` passes.