### PR TITLE
chore: add a layout probe for the viewport matrix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,9 @@ references
 # browser is driven against a local build.
 .playwright-mcp/
 
+# npm run probe writes its report and failure screenshots here.
+.probe/
+
 # Local scratch files that some editors and tools drop in the working tree.
 # Listed so a contributor cannot commit one by accident.
 Gemini.md

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "lint": "npm run lint -w client",
     "check:majors": "node scripts/check-dependency-majors.mjs",
     "check:seed": "node scripts/check-seeded-shuffle.mjs",
+    "probe": "node tools/probe/probe.mjs",
+    "probe:install": "cd tools/probe && npm install && npx playwright install chromium",
     "typecheck": "tsc --noEmit -p shared-types/tsconfig.json && tsc --noEmit -p server/tsconfig.json && tsc --noEmit -p client/tsconfig.json",
     "verify": "npm run check:majors && npm run build:shared && npm run typecheck && npm run lint && npm run format:check && npm run build:server && npm run check:seed && npm run build:client",
     "format": "prettier --write .",

--- a/tools/probe/README.md
+++ b/tools/probe/README.md
@@ -1,0 +1,87 @@
+# Layout probe
+
+Answers one question across every screen size at once: does the game fit, and
+can a player reach the controls.
+
+```
+npm run probe:install          # once
+npm run probe -- --at play --players 2 --seats 6
+```
+
+```
+      viewport        frame  content  over  controls
+--------------------------------------------------------------------------------
+FAIL  pixel5-nobar    801    820      19    all reachable
+FAIL  pixel5-bar      745    820      75    Draw from Deck (clipped), Hold to Check! (clipped)
+FAIL  iphone-se       667    781      114   Draw from Deck (offscreen), Hold to Check! (offscreen)
+FAIL  laptop-short    500    742      242   Draw from Deck (offscreen), Hold to Check! (offscreen)
+ok    desktop         1080   -        0     all reachable
+```
+
+## Running it
+
+The client and server have to be up, with timers set for scripting:
+
+```
+PEEK_DURATION_MS=200 MATCHING_STAGE_DURATION_MS=400 TURN_TIMER_MS=600000 npm run dev
+```
+
+Two of those go short and one goes long. The peek and matching windows are
+waits the driver has to sit through. The turn timer is the only one that fires
+without being asked, so a short one moves the board out from under the sweep
+and the rows stop describing the same game.
+
+## Options
+
+|               |                                                                                      |
+| ------------- | ------------------------------------------------------------------------------------ |
+| `--at`        | `lobby`, `peek`, `play`, `drawn`, `matching`. Default `play`.                        |
+| `--players`   | How many actually join, 2 to 6. Default 2.                                           |
+| `--seats`     | Lobby capacity. Defaults to `--players`. Six seats with two players is its own case. |
+| `--viewports` | `smoke` (default), `all`, or a comma separated list.                                 |
+| `--headed`    | Watch it drive.                                                                      |
+| `--verbose`   | Dump the raw measurements.                                                           |
+
+Exit code is 1 when something fails and 2 when the probe could not run at all.
+Failure screenshots and `report.json` land in `.probe/`.
+
+## How it is put together
+
+**One browser, headless clients for everyone else.** Only the observed player
+needs a rendering engine. The rest are `socket.io-client` connections in
+`player.mjs` that act the instant the server allows it, which is what makes a
+scripted round take seconds. That module is deliberately an importable API
+rather than a script, because #75 wants the same clients for wire level
+assertions and two drivers would drift.
+
+**The game is built once and every viewport re-measures it.** Sweeping seven
+sizes costs about what measuring one costs.
+
+**Driving happens at 1600x1200, not at a matrix size.** Otherwise the bug under
+test blocks the driver, and a probe that cannot click Ready because Ready is off
+screen reports a crash instead of a finding.
+
+**Measurements, not opinions.** `measure.mjs` returns numbers and every
+judgement is made in one place in `probe.mjs`, so a failure reads
+`centre y=730 in a 745 frame` rather than an assertion that tells you nothing.
+
+**Bound to `aria-label`, not classes**, so a Tailwind edit does not blind it.
+
+## Known gaps
+
+- No seed control. `CREATE_GAME` takes a name and `maxPlayers` and nothing
+  else, so each run gets a different deck and the driver has to cope with
+  whatever it deals, including a King turning a discard into an ability.
+  Seeding is #36 step 1 and is already done in the machine; plumbing it through
+  the socket payload would make runs repeatable.
+- Not wired into CI. #57 wants its own job, separate from the fast typecheck
+  workflow. Adding one is a follow up, not part of introducing the tool.
+- Layout and reachability only. The stability probe, which catches things
+  moving when nothing asked them to (#83), is the obvious next one.
+
+## Why it lives outside the workspaces
+
+`tools/probe` is not in the root `workspaces` array and has its own manifest, so
+`npm ci` at the root never installs Playwright or downloads a browser. Vercel
+and Render build from that root install, and neither has any use for a
+114MB browser.

--- a/tools/probe/measure.mjs
+++ b/tools/probe/measure.mjs
@@ -1,0 +1,117 @@
+// The measurement, serialised into the page.
+//
+// It reports numbers, never a pass/fail opinion. Judgement lives in the
+// reporter, so a failure prints "centre y=730 in a 745 frame" rather than an
+// assertion that tells you nothing about what went wrong.
+
+export function measureInPage() {
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+
+  const named = (el) => {
+    const aria = el.getAttribute("aria-label");
+    if (aria) return aria;
+    const text = (el.innerText || "").trim().replace(/\s+/g, " ");
+    return text.slice(0, 40) || `<${el.tagName.toLowerCase()}>`;
+  };
+
+  const visible = (el, style) =>
+    style.display !== "none" &&
+    style.visibility !== "hidden" &&
+    Number(style.opacity) !== 0;
+
+  // Anything that scrolls, anywhere. A game view should produce an empty list.
+  const scrollers = [];
+  for (const el of document.querySelectorAll("body *")) {
+    const style = getComputedStyle(el);
+    const scrolls = /auto|scroll/.test(style.overflowY + style.overflow);
+    const over = el.scrollHeight - el.clientHeight;
+    if (scrolls && over > 0 && visible(el, style)) {
+      scrollers.push({
+        el: el.tagName.toLowerCase(),
+        cls: String(el.className).slice(0, 60),
+        clientH: el.clientHeight,
+        scrollH: el.scrollHeight,
+        overflowPx: over,
+        scrollbarPx: el.offsetWidth - el.clientWidth,
+        // A scrollbar on the element that is also a container-query container
+        // silently changes the width its own @md: breakpoints resolve against.
+        isQueryContainer: style.containerType !== "normal",
+      });
+    }
+  }
+
+  // Every control a player has to be able to hit.
+  const controls = [];
+  for (const el of document.querySelectorAll(
+    'button:not([disabled]), [role="button"]:not([aria-disabled="true"])',
+  )) {
+    const style = getComputedStyle(el);
+    if (!visible(el, style) || style.pointerEvents === "none") continue;
+    const r = el.getBoundingClientRect();
+    if (r.width === 0 || r.height === 0) continue;
+
+    const cx = r.left + r.width / 2;
+    const cy = r.top + r.height / 2;
+    const inViewport = cx >= 0 && cx <= vw && cy >= 0 && cy <= vh;
+    const hit = inViewport ? document.elementFromPoint(cx, cy) : null;
+
+    // Fully inside, not merely centred inside. A button whose bottom half is
+    // under the fold is still a button a thumb misses.
+    const whole = r.top >= 0 && r.bottom <= vh && r.left >= 0 && r.right <= vw;
+
+    let status = "ok";
+    let blockedBy = null;
+    if (!inViewport) {
+      status = "offscreen";
+    } else if (!hit) {
+      status = "no-hit";
+    } else if (hit !== el && !el.contains(hit)) {
+      status = "obscured";
+      blockedBy = named(hit);
+    } else if (!whole) {
+      status = "clipped";
+    }
+
+    controls.push({
+      name: named(el),
+      top: Math.round(r.top),
+      bottom: Math.round(r.bottom),
+      status,
+      blockedBy,
+    });
+  }
+
+  // Full-bleed overlays: the moment stamps and the side panel. Detected by
+  // geometry and stacking rather than by class, so a rename does not blind
+  // this. An overlay that is meant to cover the screen and does not is the
+  // #82 failure, and it only shows up once something scrolls.
+  const overlays = [];
+  for (const el of document.querySelectorAll("body *")) {
+    const style = getComputedStyle(el);
+    if (style.position !== "absolute" && style.position !== "fixed") continue;
+    if (!visible(el, style)) continue;
+    const z = Number(style.zIndex);
+    if (!Number.isFinite(z) || z < 40) continue;
+    const r = el.getBoundingClientRect();
+    if (r.width < vw * 0.6 || r.height < vh * 0.6) continue;
+    overlays.push({
+      name: named(el).slice(0, 30),
+      z,
+      top: Math.round(r.top),
+      bottom: Math.round(r.bottom),
+      uncoveredTop: Math.max(0, Math.round(r.top)),
+      uncoveredBottom: Math.max(0, Math.round(vh - r.bottom)),
+    });
+  }
+
+  return {
+    viewport: { width: vw, height: vh },
+    docScrollsX:
+      document.documentElement.scrollWidth >
+      document.documentElement.clientWidth,
+    scrollers,
+    controls,
+    overlays,
+  };
+}

--- a/tools/probe/package-lock.json
+++ b/tools/probe/package-lock.json
@@ -1,0 +1,168 @@
+{
+  "name": "check-probe",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "check-probe",
+      "version": "1.0.0",
+      "dependencies": {
+        "playwright": "^1.62.1",
+        "socket.io-client": "^4.8.3"
+      }
+    },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.6",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.6.tgz",
+      "integrity": "sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.21.0",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/socket.io-client": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.7.tgz",
+      "integrity": "sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    }
+  }
+}

--- a/tools/probe/package.json
+++ b/tools/probe/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "check-probe",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Layout and reachability probe. Deliberately outside the root workspaces so it never enters the Vercel or Render install.",
+  "scripts": {
+    "probe": "node probe.mjs"
+  },
+  "dependencies": {
+    "playwright": "^1.62.1",
+    "socket.io-client": "^4.8.3"
+  }
+}

--- a/tools/probe/player.mjs
+++ b/tools/probe/player.mjs
@@ -1,0 +1,145 @@
+// A player that is not a browser.
+//
+// Every player except the one being observed is one of these. They act the
+// instant the server lets them, which is what makes a scripted round take
+// seconds instead of the minutes it takes to drive two browsers by hand.
+//
+// #75 wants the same thing for wire-level assertions, so this is a module with
+// an action API rather than a script. Keep it that way: two drivers would
+// drift, and the whole point is that there is one.
+
+import { io } from "socket.io-client";
+
+const SERVER = process.env.PROBE_SERVER_URL ?? "http://localhost:8000";
+
+/** Resolves when `predicate(state)` holds, or rejects on timeout. Every wait in
+ *  the driver goes through this rather than a sleep, so a slow machine costs
+ *  latency instead of a flake. */
+const waitFor = (player, predicate, label, timeoutMs = 15000) =>
+  new Promise((resolve, reject) => {
+    if (player.state && predicate(player.state)) return resolve(player.state);
+    const timer = setTimeout(() => {
+      player.off(check);
+      // A timeout is nearly always a rejected action rather than a slow one,
+      // and the server answers a rejection with ERROR_MESSAGE rather than by
+      // failing the emit. Without these the failure says nothing.
+      const s = player.state;
+      const detail = s
+        ? `stage=${s.gameStage} phase=${s.turnPhase} ` +
+          `turn=${s.currentPlayerId === player.id ? "mine" : (s.currentPlayerId ?? "none")}`
+        : "no state received";
+      const errors = player.errors.length
+        ? `\n  server said: ${player.errors.slice(-3).join("; ")}`
+        : "\n  server reported no error, so the action was accepted and did not change this";
+      reject(
+        new Error(
+          `${player.name} timed out after ${timeoutMs}ms waiting for ${label}\n  ${detail}${errors}`,
+        ),
+      );
+    }, timeoutMs);
+    const check = (state) => {
+      if (!predicate(state)) return;
+      clearTimeout(timer);
+      player.off(check);
+      resolve(state);
+    };
+    player.on(check);
+  });
+
+export class HeadlessPlayer {
+  constructor(name) {
+    this.name = name;
+    this.id = null;
+    this.gameId = null;
+    this.state = null;
+    this.errors = [];
+    this.listeners = new Set();
+    this.socket = io(SERVER, { transports: ["websocket"] });
+    this.socket.on("GAME_STATE_UPDATE", (state) => {
+      this.state = state;
+      for (const l of [...this.listeners]) l(state);
+    });
+    this.socket.on("ERROR_MESSAGE", (e) => this.errors.push(e?.message ?? e));
+  }
+
+  on(fn) {
+    this.listeners.add(fn);
+  }
+  off(fn) {
+    this.listeners.delete(fn);
+  }
+
+  #emit(event, ...args) {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error(`${event} never acknowledged`)),
+        10000,
+      );
+      this.socket.emit(event, ...args, (response) => {
+        clearTimeout(timer);
+        if (!response?.success) {
+          return reject(
+            new Error(`${event} failed: ${response?.message ?? "no reason"}`),
+          );
+        }
+        resolve(response);
+      });
+    });
+  }
+
+  async connected() {
+    if (this.socket.connected) return;
+    await new Promise((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error(`no connection to ${SERVER}`)),
+        10000,
+      );
+      this.socket.once("connect", () => {
+        clearTimeout(timer);
+        resolve();
+      });
+      this.socket.once("connect_error", (e) => {
+        clearTimeout(timer);
+        reject(new Error(`connection to ${SERVER} refused: ${e.message}`));
+      });
+    });
+  }
+
+  async createGame({ seats }) {
+    await this.connected();
+    const res = await this.#emit("CREATE_GAME", {
+      name: this.name,
+      maxPlayers: seats,
+    });
+    this.id = res.playerId;
+    this.gameId = res.gameId;
+    return res.gameId;
+  }
+
+  async joinGame(gameId) {
+    await this.connected();
+    const res = await this.#emit("JOIN_GAME", gameId, { name: this.name });
+    this.id = res.playerId;
+    this.gameId = gameId;
+    return res.playerId;
+  }
+
+  /** Fire and forget: the server answers every action with a broadcast, not an
+   *  ack, so callers wait on state rather than on this. */
+  act(type, payload) {
+    this.socket.emit("PLAYER_ACTION", { type, payload });
+  }
+
+  waitFor(predicate, label, timeoutMs) {
+    return waitFor(this, predicate, label, timeoutMs);
+  }
+
+  /** True once this player is the one the server is waiting on. */
+  get isMyTurn() {
+    return this.state?.currentPlayerId === this.id;
+  }
+
+  disconnect() {
+    this.socket.close();
+  }
+}

--- a/tools/probe/probe.mjs
+++ b/tools/probe/probe.mjs
@@ -1,0 +1,418 @@
+// Layout and reachability probe.
+//
+//   node tools/probe/probe.mjs --at play --players 2 --seats 6
+//
+// One browser for the observed player, headless socket clients for the rest,
+// then the viewport matrix swept against a single live game. The game is built
+// once and every viewport re-measures it, which is why sweeping seven sizes
+// costs about as much as measuring one.
+//
+// It reports measurements. Judgement is at the bottom, in one place.
+
+import { chromium } from "playwright";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { HeadlessPlayer } from "./player.mjs";
+import { resolve as resolveViewports } from "./viewports.mjs";
+import { measureInPage } from "./measure.mjs";
+
+const CLIENT = process.env.PROBE_CLIENT_URL ?? "http://localhost:3000";
+const SERVER = process.env.PROBE_SERVER_URL ?? "http://localhost:8000";
+// Anchored to the repo, not to the shell's directory, so output lands in the
+// same place whether this is run from the root or from tools/probe.
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const OUT = join(ROOT, ".probe");
+
+const CHECKPOINTS = ["lobby", "peek", "play", "drawn", "matching"];
+
+const argv = process.argv.slice(2);
+const arg = (name, fallback) => {
+  const i = argv.indexOf(`--${name}`);
+  return i === -1 ? fallback : argv[i + 1];
+};
+const flag = (name) => argv.includes(`--${name}`);
+
+const opts = {
+  at: arg("at", "play"),
+  players: Number(arg("players", 2)),
+  seats: Number(arg("seats", 2)),
+  viewports: arg("viewports", "smoke"),
+  headed: flag("headed"),
+  verbose: flag("verbose"),
+};
+
+if (!CHECKPOINTS.includes(opts.at)) {
+  console.error(
+    `unknown checkpoint "${opts.at}"\nknown: ${CHECKPOINTS.join(", ")}`,
+  );
+  process.exit(2);
+}
+if (opts.players < 2 || opts.players > 6) {
+  console.error("--players must be between 2 and 6");
+  process.exit(2);
+}
+if (opts.seats < opts.players) opts.seats = opts.players;
+
+// ---------------------------------------------------------------------------
+// Preflight
+// ---------------------------------------------------------------------------
+
+const reachable = async (url) => {
+  try {
+    await fetch(url, { signal: AbortSignal.timeout(3000) });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const preflight = async () => {
+  const problems = [];
+  if (!(await reachable(`${SERVER}/health`))) {
+    problems.push(`  server not answering at ${SERVER}/health`);
+  }
+  if (!(await reachable(CLIENT))) {
+    problems.push(`  client not answering at ${CLIENT}`);
+  }
+  if (problems.length) {
+    console.error(`\nNothing to probe.\n${problems.join("\n")}\n`);
+    console.error("Start both with timers set for scripting:\n");
+    console.error(
+      "  PEEK_DURATION_MS=200 MATCHING_STAGE_DURATION_MS=400 TURN_TIMER_MS=600000 npm run dev\n",
+    );
+    console.error(
+      "Those three are already environment variables, read at\n" +
+        "server/src/game-machine.ts:43,46,75. Left at their defaults a scripted\n" +
+        "round waits 10s for the peek alone.\n\n" +
+        "The turn timer goes the other way, long rather than short. It is the\n" +
+        "only one that fires without being asked, so a short one moves the board\n" +
+        "out from under the sweep and rows stop describing the same game.\n",
+    );
+    process.exit(2);
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Driver
+// ---------------------------------------------------------------------------
+
+const GameStage = {
+  WAITING: "WAITING_FOR_PLAYERS",
+  DEALING: "DEALING",
+  INITIAL_PEEK: "INITIAL_PEEK",
+  PLAYING: "PLAYING",
+};
+
+/** Declines whatever ability is on the stack, however many decision windows it
+ *  wants. A King is peek-two then swap-one, so one skip is not always enough. */
+const skipAnyAbility = async (player) => {
+  for (let guard = 0; guard < 6; guard++) {
+    if (player.state?.turnPhase !== "ABILITY") return;
+    player.act("USE_ABILITY", { action: "skip" });
+    await player
+      .waitFor((s) => s.turnPhase !== "ABILITY", "the ability to clear", 3000)
+      .catch(() => {}); // a multi-stage ability stays in ABILITY; loop again
+  }
+  if (player.state?.turnPhase === "ABILITY") {
+    throw new Error("could not decline the ability after six attempts");
+  }
+};
+
+/** Builds the game up to `at` and returns the browser page sitting in it. */
+const drive = async (page, opts) => {
+  const bots = [];
+  const host = new HeadlessPlayer("Host");
+  bots.push(host);
+  const gameId = await host.createGame({ seats: opts.seats });
+
+  // Everyone except the observed player. The observed player is the browser.
+  for (let i = bots.length; i < opts.players - 1; i++) {
+    const bot = new HeadlessPlayer(`Bot${i}`);
+    await bot.joinGame(gameId);
+    bots.push(bot);
+  }
+
+  // The browser joins the way a person does, through the dialog, so the join
+  // path itself is covered rather than bypassed by seeding localStorage.
+  await page.goto(`${CLIENT}/game/${gameId}`, {
+    waitUntil: "domcontentloaded",
+  });
+  const dialog = page.locator('[role="dialog"]');
+  await dialog.locator("input").first().fill("Observed");
+  await dialog.getByRole("button", { name: /confirm and join/i }).click();
+
+  await host.waitFor(
+    (s) => Object.keys(s.players ?? {}).length === opts.players,
+    `${opts.players} players seated`,
+  );
+
+  if (opts.at === "lobby") return { gameId, bots };
+
+  for (const bot of bots) bot.act("DECLARE_LOBBY_READY");
+  await page
+    .getByRole("button", { name: /^ready up$/i })
+    .click({ timeout: 10000 });
+  await host.waitFor(
+    (s) => Object.values(s.players).every((p) => p.isReady),
+    "everyone ready",
+  );
+
+  host.act("START_GAME");
+  // Wait for INITIAL_PEEK itself, not merely for the lobby to end. DEALING
+  // sits in between for 100ms and has no handler for the peek declaration, so
+  // a declaration sent during it is dropped on the floor and the game waits
+  // for a ready that already happened.
+  await host.waitFor(
+    (s) => s.gameStage === GameStage.INITIAL_PEEK,
+    "the initial peek to open",
+  );
+
+  if (opts.at === "peek") return { gameId, bots, observedId: null };
+
+  // Every player has to declare, including the browser: the only thing that
+  // opens the window without them is the ready-stall timeout, which is the
+  // turn timer, and that is deliberately long here so the board holds still
+  // during the sweep.
+  for (const bot of bots) bot.act("DECLARE_READY_FOR_PEEK");
+  await page
+    .getByRole("button", { name: /ready for peek/i })
+    .click({ timeout: 15000 });
+  await host.waitFor(
+    (s) => s.gameStage === GameStage.PLAYING,
+    "playing",
+    30000,
+  );
+
+  // Whose seat is the browser holding? Needed because the action bar only
+  // renders on your own turn, and measuring a board where someone else is
+  // acting misses every control that matters.
+  const observedId = await page.evaluate(() => {
+    const raw = localStorage.getItem("playerSession");
+    return raw ? JSON.parse(raw).playerId : null;
+  });
+  if (!observedId) throw new Error("browser player never got a session");
+
+  /** Plays whole bot turns until the browser player is the one on the clock. */
+  const passTurnToObserved = async () => {
+    for (let guard = 0; guard < opts.players * 2; guard++) {
+      if (host.state?.currentPlayerId === observedId) return;
+      const turn = bots.find((b) => b.isMyTurn);
+      if (!turn) {
+        await host.waitFor(
+          (s) =>
+            s.currentPlayerId === observedId || bots.some((b) => b.isMyTurn),
+          "someone to hold the turn",
+        );
+        continue;
+      }
+      turn.act("DRAW_FROM_DECK");
+      await turn.waitFor(
+        (s) => !!s.players[turn.id]?.pendingDrawnCard,
+        "the bot's drawn card",
+      );
+      turn.act("DISCARD_DRAWN_CARD");
+      // A discarded King, Queen or Jack opens an ability instead of a matching
+      // window, so the two have to be waited on together. Whichever the deck
+      // deals is not something the driver gets to choose: CREATE_GAME takes no
+      // seed, so every run gets a different deck.
+      await turn.waitFor(
+        (s) => !!s.matchingOpportunity || s.turnPhase === "ABILITY",
+        "the matching window or an ability",
+      );
+      await skipAnyAbility(turn);
+      if (host.state?.matchingOpportunity) {
+        for (const b of bots) b.act("PASS_ON_MATCH_ATTEMPT");
+        await host.waitFor(
+          (s) => !s.matchingOpportunity,
+          "the matching window to close",
+        );
+      }
+      await skipAnyAbility(turn);
+    }
+    throw new Error("could not hand the turn to the observed player");
+  };
+
+  if (opts.at === "play") {
+    await passTurnToObserved();
+    return { gameId, bots, observedId };
+  }
+
+  // The remaining checkpoints are about what the board looks like mid-turn, so
+  // the observed player takes the turn rather than a bot.
+  await passTurnToObserved();
+  await page.getByRole("button", { name: /draw from deck/i }).click();
+  await host.waitFor(
+    (s) => !!s.players[observedId]?.pendingDrawnCard,
+    "the observed player's drawn card",
+  );
+
+  if (opts.at === "drawn") return { gameId, bots, observedId };
+
+  await page.getByRole("button", { name: /discard card/i }).click();
+  await host.waitFor((s) => !!s.matchingOpportunity, "the matching window");
+  return { gameId, bots, observedId };
+};
+
+// ---------------------------------------------------------------------------
+// Report
+// ---------------------------------------------------------------------------
+
+const pad = (s, n) => String(s).padEnd(n);
+
+const report = (rows, opts) => {
+  let failures = 0;
+  console.log(
+    `\n${pad("", 6)}${pad("viewport", 16)}${pad("frame", 7)}${pad("content", 9)}${pad("over", 6)}controls`,
+  );
+  console.log("-".repeat(80));
+
+  for (const { viewport, m } of rows) {
+    const worst = m.scrollers.sort((a, b) => b.overflowPx - a.overflowPx)[0];
+    const bad = m.controls.filter((c) => c.status !== "ok");
+    // A game view that scrolls at all is a failure, whether or not the scroll
+    // makes anything unreachable. That is the whole of #82.
+    const failed = bad.length > 0 || !!worst;
+    if (failed) failures++;
+
+    console.log(
+      pad(failed ? "FAIL" : "ok", 6) +
+        pad(viewport.name, 16) +
+        pad(viewport.height, 7) +
+        pad(worst ? worst.scrollH : "-", 9) +
+        pad(worst ? worst.overflowPx : 0, 6) +
+        (bad.length
+          ? bad.map((c) => `${c.name} (${c.status})`).join(", ")
+          : "all reachable"),
+    );
+
+    for (const o of m.overlays) {
+      if (o.uncoveredTop > 1 || o.uncoveredBottom > 1) {
+        console.log(
+          `  ${pad("", 14)}overlay "${o.name}" leaves ${o.uncoveredTop}px top / ${o.uncoveredBottom}px bottom uncovered`,
+        );
+      }
+    }
+    // Only when the scrollbar actually takes width. Headless Chromium uses
+    // overlay scrollbars, so a 0px one here says nothing about a desktop
+    // browser that reserves 15px for the same bar.
+    if (worst?.isQueryContainer && worst.scrollbarPx > 0) {
+      console.log(
+        `  ${pad("", 20)}the scrolling element is also a container-query container: ` +
+          `its ${worst.scrollbarPx}px scrollbar changes the width its own @md: rules resolve against`,
+      );
+    }
+    if (m.docScrollsX) {
+      console.log(`  ${pad("", 14)}the document scrolls horizontally`);
+    }
+  }
+
+  console.log("");
+  if (opts.verbose) console.log(JSON.stringify(rows, null, 2));
+  return failures;
+};
+
+// ---------------------------------------------------------------------------
+
+const main = async () => {
+  await preflight();
+  mkdirSync(OUT, { recursive: true });
+
+  const viewports = resolveViewports(opts.viewports);
+  const browser = await chromium.launch({ headless: !opts.headed });
+  // A fresh context every run: identity lives in localStorage as
+  // `playerSession`, and a stale one makes the client try to rejoin a game the
+  // server no longer has.
+  // The game is built at a size nothing can be unreachable at, then the matrix
+  // is swept. Driving at a matrix size would let the bug under test block the
+  // driver: a probe that cannot click Ready because Ready is off screen reports
+  // a crash instead of a finding.
+  const context = await browser.newContext({
+    viewport: { width: 1600, height: 1200 },
+    deviceScaleFactor: 1,
+  });
+  const page = await context.newPage();
+
+  const consoleErrors = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") consoleErrors.push(msg.text());
+  });
+  page.on("pageerror", (e) => consoleErrors.push(String(e)));
+
+  let bots = [];
+  let failures = 0;
+  try {
+    console.log(
+      `building: ${opts.players} players, ${opts.seats} seats, stopping at "${opts.at}"`,
+    );
+    let observedId;
+    ({ bots, observedId } = await drive(page, opts));
+
+    // Every row has to describe the same game, or the table is comparing
+    // different boards and quietly says nothing.
+    const stamp = () => {
+      const s = bots[0].state;
+      return `${s?.gameStage}/${s?.turnPhase}/${s?.currentPlayerId}`;
+    };
+    const before = stamp();
+
+    const rows = [];
+    for (const viewport of viewports) {
+      await page.setViewportSize(viewport);
+      // One frame for the container queries and any layout animation to settle
+      // before measuring, otherwise the first row reads mid-transition.
+      await page.waitForTimeout(250);
+      const m = await page.evaluate(measureInPage);
+      rows.push({ viewport, m });
+
+      const unreachable = m.controls.some((c) => c.status !== "ok");
+      if (unreachable || m.scrollers.length) {
+        await page.screenshot({
+          path: join(OUT, `${opts.at}-${viewport.name}.png`),
+        });
+      }
+    }
+
+    const after = stamp();
+    if (before !== after) {
+      console.log(
+        `\nWARNING: the game moved during the sweep (${before} -> ${after}).\n` +
+          `Rows below may describe different boards. Raise TURN_TIMER_MS.`,
+      );
+    }
+
+    failures = report(rows, opts);
+    writeFileSync(
+      join(OUT, "report.json"),
+      JSON.stringify({ opts, rows, consoleErrors }, null, 2),
+    );
+    console.log(`detail -> ${join(OUT, "report.json")}`);
+
+    if (consoleErrors.length) {
+      failures++;
+      console.log(`\n${consoleErrors.length} console error(s):`);
+      for (const e of consoleErrors.slice(0, 5)) console.log(`  ${e}`);
+    }
+  } finally {
+    for (const bot of bots) bot.disconnect();
+    await browser.close();
+  }
+
+  process.exit(failures ? 1 : 0);
+};
+
+main().catch((e) => {
+  if (
+    e.code === "ERR_MODULE_NOT_FOUND" ||
+    /playwright/i.test(e.message ?? "")
+  ) {
+    console.error(
+      "\nThe probe's own dependencies are not installed. They live outside the\n" +
+        "root workspaces on purpose, so that Vercel and Render never install a\n" +
+        "browser they have no use for.\n\n  npm run probe:install\n",
+    );
+    process.exit(2);
+  }
+  console.error(`\nprobe failed: ${e.message}\n`);
+  process.exit(2);
+});

--- a/tools/probe/viewports.mjs
+++ b/tools/probe/viewports.mjs
@@ -1,0 +1,48 @@
+// The device matrix.
+//
+// Phones get two rows, not one. `h-screen` is overridden to `100dvh` in
+// globals.css, so the frame grows and shrinks by the height of the browser's
+// URL bar while the content, sized in `svh` and fixed pixels, does not move.
+// A board can fit one of those states and overflow the other, and testing only
+// the taller one is how #82 was first miscalled as the board never having fit.
+//
+// Heights are the browser viewport, not the device screen: screen height minus
+// the URL bar, and minus the Android navigation bar where there is one.
+
+export const VIEWPORTS = [
+  { name: "pixel5-nobar", width: 393, height: 801 },
+  { name: "pixel5-bar", width: 393, height: 745 },
+  { name: "iphone-se", width: 375, height: 667 },
+  { name: "ipad-portrait", width: 820, height: 1080 },
+  { name: "laptop-short", width: 1280, height: 500 },
+  { name: "laptop", width: 1440, height: 780 },
+  { name: "desktop", width: 1920, height: 1080 },
+];
+
+/** The cells a pull request runs. The full sweep is for the nightly job. Any
+ *  cell that has ever failed belongs in here permanently. */
+export const SMOKE = new Set([
+  "pixel5-bar",
+  "pixel5-nobar",
+  "iphone-se",
+  "laptop-short",
+  "desktop",
+]);
+
+export const resolve = (names) => {
+  if (!names || names === "smoke") {
+    return VIEWPORTS.filter((v) => SMOKE.has(v.name));
+  }
+  if (names === "all") return VIEWPORTS;
+  const wanted = new Set(String(names).split(","));
+  const picked = VIEWPORTS.filter((v) => wanted.has(v.name));
+  const unknown = [...wanted].filter(
+    (n) => !VIEWPORTS.some((v) => v.name === n),
+  );
+  if (unknown.length) {
+    throw new Error(
+      `unknown viewport: ${unknown.join(", ")}\nknown: ${VIEWPORTS.map((v) => v.name).join(", ")}`,
+    );
+  }
+  return picked;
+};


### PR DESCRIPTION
First slice of #57. One command answers whether the game fits and whether a player can reach the controls, across every screen size at once.

```
npm run probe:install                              # once
npm run probe -- --at play --players 2 --seats 6
```

```
      viewport        frame  content  over  controls
--------------------------------------------------------------------------------
FAIL  pixel5-nobar    801    820      19    all reachable
FAIL  pixel5-bar      745    820      75    Draw from Deck (clipped), Hold to Check! (clipped)
FAIL  iphone-se       667    781      114   Draw from Deck (offscreen), Hold to Check! (offscreen)
FAIL  laptop-short    500    742      242   Draw from Deck (offscreen), Hold to Check! (offscreen)
ok    desktop         1080   -        0     all reachable
```

## Why now

#81 is the change PR #34 attempted twice and was rolled back twice for breaking the board, and its own text warns that card sizing, the action bar and seat placement are exactly what #34 touched when it broke. Doing that again with a person eyeballing one viewport is how a third rollback happens.

It also reproduces the findings behind #82 and #81 rather than taking them on trust:

- 242px over at 1280x500, which is the figure `c315f0a` measured by hand.
- The Pixel 5 fits with the URL bar collapsed and overflows by 75px with it showing, which is the distinction that made the board first look like it had never fit.
- The lobby at two seats fits every phone; at six seats it is 837px and overflows by 92px on a Pixel 5 and 170px on an iPhone SE. That is the lobby half of #81, measured.

## Shape

**One browser, headless clients for everyone else.** Only the observed player needs a rendering engine. The rest are `socket.io-client` connections that act the instant the server allows it, which is what turns a scripted round from minutes into seconds. `player.mjs` is an importable API rather than a script because #75 wants the same clients for wire level assertions, and two drivers would drift.

**Built once, measured many times.** The game is driven to a checkpoint and then every viewport re-measures the same board, so seven sizes cost about what one costs.

**Driving happens at 1600x1200**, not at a matrix size. Otherwise the bug under test blocks the driver, and a probe that cannot click Ready because Ready is off screen reports a crash instead of a finding.

**Measurements, not opinions.** `measure.mjs` returns numbers; every judgement is made in one place. A failure reads `centre y=730 in a 745 frame`, not an assertion.

**Bound to `aria-label`**, so a Tailwind edit does not blind it.

## Two things it found while being built

Both are in the driver, not the app, but both are the kind of thing that would have made a hand written script quietly wrong:

- `DECLARE_READY_FOR_PEEK` sent during `DEALING` is dropped, because that state has no handler for it. The peek then waits forever on a ready that already happened. The driver now waits for `INITIAL_PEEK` itself rather than for the lobby to end.
- The turn timer wants to be **long**, not short, which is the opposite of the other two. It is the only timer that fires without being asked, so a short one moves the board out from under the sweep and the rows stop describing the same game. The probe now warns when the state changes mid sweep.

## Deploy safety

`tools/probe` is deliberately outside the root `workspaces` array and carries its own manifest and lockfile, so `npm ci` at the root never installs Playwright or downloads a 114MB browser. Vercel and Render build from that root install. `npm run check:majors` only inspects the client and server manifests, so its expectations are untouched.

Verified with `npm run verify`, and the probe was run four times against a live two player game to confirm it is stable rather than lucky.

## Not in this PR

- No CI job. #57 wants its own, separate from the fast typecheck workflow, and adding a required check that needs a browser and two servers deserves its own change.
- No seed control. `CREATE_GAME` takes a name and `maxPlayers` and nothing else, so every run gets a different deck and the driver copes with whatever it deals, including a King turning a discard into an ability. Plumbing the existing seed through the socket payload would make runs repeatable.
- Layout and reachability only. The stability probe, which catches things moving when nothing asked them to, is the next one and is what #83 needs.
