### PR TITLE
feat: show every player's series wins on the end screen

### DIFF
--- a/client/components/game/RoundSummary.tsx
+++ b/client/components/game/RoundSummary.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import { motion, useReducedMotion } from "framer-motion";
-import { Crown } from "lucide-react";
+import { Crown, Trophy } from "lucide-react";
 import { type Player, PlayerStatus } from "shared-types";
 import {
   useUIActorRef,
@@ -108,26 +108,16 @@ export const RoundSummary = ({
     ? `${caller.name} called Check.`
     : "The round ended without a Check.";
 
-  // Series standing across Play Agains — the kicker reads as a scoreboard.
-  // playerWins accumulates for the lobby's lifetime and roundEpoch counts
-  // the Play Agains, so this round is epoch + 1. By the time the sheet is
-  // up, calculateScores has already credited this round's winner.
+  // playerWins accumulates for the lobby's lifetime and roundEpoch counts the
+  // Play Agains, so this round is epoch + 1. By the time the sheet is up,
+  // calculateScores has already credited this round's winner.
+  //
+  // The series standing used to live here as one sentence, which could only
+  // ever name the leader and a runner-up. Past two players that hid everyone
+  // else, so it now rides on the rows instead, where every player already has
+  // one.
   const roundNumber = roundEpoch + 1;
-  const standings = players
-    .map((p) => ({ name: p.name, wins: playerWins[p.id] ?? 0 }))
-    .sort((a, b) => b.wins - a.wins);
-  const leader = standings[0];
-  const coLeaders = leader
-    ? standings.filter((s) => s.wins === leader.wins)
-    : [];
-  const series =
-    !leader || leader.wins === 0
-      ? null
-      : coLeaders.length === 1
-        ? `${leader.name} leads ${leader.wins}–${standings[1]?.wins ?? 0}`
-        : coLeaders.length === 2
-          ? `${coLeaders[0]!.name} and ${coLeaders[1]!.name} tied at ${leader.wins}`
-          : `Tied at ${leader.wins}`;
+  const seriesStarted = players.some((p) => (playerWins[p.id] ?? 0) > 0);
 
   // One-shot recap from the accumulated log (append-only; merged in the
   // machine). Counted once on mount. Late joiners hold only a log tail, so
@@ -171,7 +161,6 @@ export const RoundSummary = ({
         <div>
           <p className="truncate text-xs font-semibold uppercase tracking-widest text-ink-muted">
             Round {roundNumber}
-            {series && ` · ${series}`}
           </p>
           <h2 className="mt-1 text-3xl font-extrabold tracking-tight text-ink sm:text-4xl">
             {title}
@@ -239,6 +228,21 @@ export const RoundSummary = ({
                     </span>
                   )}
                 </span>
+                {/* Series wins, on every row so a six player table can see
+                    the whole standing. Trophy rather than the Crown above it:
+                    the crown marks who took THIS round, and the two numbers
+                    would otherwise read as the same thing. Hidden until
+                    someone has actually won one, so a first round does not
+                    show a column of zeroes. */}
+                {seriesStarted && (
+                  <span
+                    className="flex shrink-0 items-center gap-1 text-sm font-semibold tabular-nums text-ink-muted"
+                    aria-label={`${playerWins[player.id] ?? 0} rounds won this series`}
+                  >
+                    <Trophy className="h-3.5 w-3.5" aria-hidden />
+                    {playerWins[player.id] ?? 0}
+                  </span>
+                )}
                 <ScoreStamp
                   value={player.score}
                   delay={FIRST_STAMP_DELAY_S + i * STAMP_STAGGER_S}

--- a/tools/probe/probe.mjs
+++ b/tools/probe/probe.mjs
@@ -24,7 +24,7 @@ const SERVER = process.env.PROBE_SERVER_URL ?? "http://localhost:8000";
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const OUT = join(ROOT, ".probe");
 
-const CHECKPOINTS = ["lobby", "peek", "play", "drawn", "matching"];
+const CHECKPOINTS = ["lobby", "peek", "play", "drawn", "matching", "scoring"];
 
 const argv = process.argv.slice(2);
 const arg = (name, fallback) => {
@@ -194,9 +194,55 @@ const drive = async (page, opts) => {
   });
   if (!observedId) throw new Error("browser player never got a session");
 
+  /** One whole bot turn: draw, discard, clear whatever that opened. Returns
+   *  false when this seat could not act, which is normal rather than fatal at
+   *  six players (locked after check, disqualified on hand size, mid
+   *  reshuffle, or the turn simply moved). */
+  const playBotTurn = async (turn) => {
+    // An ability can be waiting before this bot has drawn anything: a match on
+    // a special card hands one to whoever made it, so a turn can open in
+    // ABILITY rather than DRAW, and DRAW_FROM_DECK is refused there.
+    await skipAnyAbility(turn);
+    turn.act("DRAW_FROM_DECK");
+    try {
+      await turn.waitFor(
+        (s) => !!s.players[turn.id]?.pendingDrawnCard,
+        "the bot's drawn card",
+        6000,
+      );
+    } catch {
+      return false;
+    }
+    turn.act("DISCARD_DRAWN_CARD");
+    // A discarded King, Queen or Jack opens an ability instead of a matching
+    // window, so the two have to be waited on together. Whichever the deck
+    // deals is not something the driver gets to choose: CREATE_GAME takes no
+    // seed, so every run gets a different deck.
+    await turn
+      .waitFor(
+        (s) => !!s.matchingOpportunity || s.turnPhase === "ABILITY",
+        "the matching window or an ability",
+        8000,
+      )
+      .catch(() => {});
+    await skipAnyAbility(turn);
+    if (host.state?.matchingOpportunity) {
+      for (const b of bots) b.act("PASS_ON_MATCH_ATTEMPT");
+      await host
+        .waitFor(
+          (s) => !s.matchingOpportunity,
+          "the matching window to close",
+          8000,
+        )
+        .catch(() => {});
+    }
+    await skipAnyAbility(turn);
+    return true;
+  };
+
   /** Plays whole bot turns until the browser player is the one on the clock. */
   const passTurnToObserved = async () => {
-    for (let guard = 0; guard < opts.players * 2; guard++) {
+    for (let guard = 0; guard < opts.players * 3; guard++) {
       if (host.state?.currentPlayerId === observedId) return;
       // Whose turn it is comes from one socket's view, not from each bot's own.
       // With six players the broadcasts land at slightly different moments and
@@ -211,49 +257,79 @@ const drive = async (page, opts) => {
         );
         continue;
       }
-      // An ability can be waiting before this bot has drawn anything: a match
-      // on a special card hands one to whoever made it, so a turn can open in
-      // ABILITY rather than DRAW, and DRAW_FROM_DECK is refused there.
-      await skipAnyAbility(turn);
-      turn.act("DRAW_FROM_DECK");
-      try {
-        await turn.waitFor(
-          (s) => !!s.players[turn.id]?.pendingDrawnCard,
-          "the bot's drawn card",
-          6000,
-        );
-      } catch {
-        // The turn moved, or this seat cannot draw right now: locked after
-        // calling check, disqualified on hand size, or mid reshuffle. Re-read
-        // who is on the clock and try again rather than insisting this bot
-        // must be the one to act. Six players make these overlap often enough
-        // that treating it as fatal only produces flaky runs.
-        continue;
-      }
-      turn.act("DISCARD_DRAWN_CARD");
-      // A discarded King, Queen or Jack opens an ability instead of a matching
-      // window, so the two have to be waited on together. Whichever the deck
-      // deals is not something the driver gets to choose: CREATE_GAME takes no
-      // seed, so every run gets a different deck.
-      await turn.waitFor(
-        (s) => !!s.matchingOpportunity || s.turnPhase === "ABILITY",
-        "the matching window or an ability",
-      );
-      await skipAnyAbility(turn);
-      if (host.state?.matchingOpportunity) {
-        for (const b of bots) b.act("PASS_ON_MATCH_ATTEMPT");
-        await host.waitFor(
-          (s) => !s.matchingOpportunity,
-          "the matching window to close",
-        );
-      }
-      await skipAnyAbility(turn);
+      await playBotTurn(turn);
     }
     throw new Error("could not hand the turn to the observed player");
   };
 
   if (opts.at === "play") {
     await passTurnToObserved();
+    return { gameId, bots, observedId };
+  }
+
+  if (opts.at === "scoring") {
+    // A bot calls it rather than the browser: CALL_CHECK goes straight down
+    // the socket, where the button is a press-and-hold that would have to be
+    // simulated. Then everyone takes their final turn and the round scores.
+    const caller = bots.find((b) => b.id === host.state?.currentPlayerId);
+    if (!caller) {
+      await host.waitFor(
+        (s) => bots.some((b) => b.id === s.currentPlayerId),
+        "a bot to hold the turn so it can call check",
+      );
+    }
+    (bots.find((b) => b.id === host.state?.currentPlayerId) ?? bots[0]).act(
+      "CALL_CHECK",
+    );
+    await host.waitFor(
+      (s) =>
+        s.gameStage !== GameStage.PLAYING ||
+        s.checkCalledBy ||
+        Object.values(s.players).some((p) => p.hasCalledCheck),
+      "check to be called",
+    );
+
+    // Final turns. Whoever is on the clock plays, browser included, until the
+    // round scores.
+    for (let guard = 0; guard < opts.players * 3; guard++) {
+      if (
+        host.state?.gameStage === "SCORING" ||
+        host.state?.gameStage === "GAMEOVER"
+      ) {
+        break;
+      }
+      const turn = bots.find((b) => b.id === host.state?.currentPlayerId);
+      if (turn) {
+        await playBotTurn(turn);
+        continue;
+      }
+      if (host.state?.currentPlayerId === observedId) {
+        await page
+          .getByRole("button", { name: /draw from deck/i })
+          .click({ timeout: 8000 })
+          .catch(() => {});
+        await page
+          .getByRole("button", { name: /discard card/i })
+          .click({ timeout: 8000 })
+          .catch(() => {});
+      }
+      await host
+        .waitFor(
+          (s) => s.currentPlayerId !== observedId,
+          "the turn to move on",
+          6000,
+        )
+        .catch(() => {});
+    }
+    await host.waitFor(
+      (s) => s.gameStage === "SCORING" || s.gameStage === "GAMEOVER",
+      "the round to score",
+      30000,
+    );
+    // The sheet is deliberately held back ~1.1s so the last card flight can
+    // land before it covers the table. Measuring before that catches the board
+    // mid animation with no sheet on it.
+    await page.waitForTimeout(1800);
     return { gameId, bots, observedId };
   }
 


### PR DESCRIPTION
Closes #39.

The end screen already built the full standing and then threw it away:

```js
const standings = players
  .map((p) => ({ name: p.name, wins: playerWins[p.id] ?? 0 }))
  .sort((a, b) => b.wins - a.wins);
```

collapsed into one sentence that can hold at most two names. One leader names the leader and an anonymous runner-up number, two co-leaders name two, three or more name nobody at all. At six players four people were invisible in every branch. That copy was written when the table was two people.

Wins now ride on the player rows, which already list everyone, and the sentence retires. A trophy rather than the crown beside it: the crown marks who took this round, and two numbers under one glyph would read as the same thing. Hidden until someone has actually won a round, so a first round does not show a column of zeroes.

Per round card scores already listed every player and are untouched.

## Not a scoring change

#39 also carried a second half, card points accumulating across rounds. That is dropped, and the reasoning is recorded in the issue: it needs new server state, redactor pass through and reset semantics, and it changes how the game is scored rather than what is shown. If it comes back it gets its own issue and its own rules decision.

No server work, no rules change, no new state.

## Verification

Adds a `scoring` checkpoint to the probe, so the end screen can be measured and screenshotted rather than reasoned about. A bot calls check down the socket, since the button is a press and hold, everyone takes a final turn, and the sheet is given its deliberate 1.1s hold before anything is measured.

Checked by screenshot at six players: all six rows present, each carrying its win count, crown still on the round winner.

Also refactors one bot turn out of the turn-passing loop so both paths share it, and makes a seat that cannot act non fatal. At six players that is ordinary rather than exceptional: locked after calling check, disqualified on hand size, holding an ability handed over by someone else's match, or the turn simply having moved.

## One thing this PR does not fix

The probe found the end sheet overflows its own `max-h-[50vh]` scroller at six players, putting Play again, Table talk and Back to home below the fold, on desktop as well as on phones.

That is **pre-existing**. With this change reverted and the probe kept, the numbers are identical: 216px over at pixel5-bar and 138px at desktop, the same three buttons offscreen. The trophy column adds width, not height. Filed separately rather than folded in here.
