### PR TITLE
fix: stop seats drifting sideways when a status word changes length

### DIFF
--- a/client/components/game/PlayerHandStrip.tsx
+++ b/client/components/game/PlayerHandStrip.tsx
@@ -143,7 +143,14 @@ const PlayerInfoBadge = ({
   // local player keeps its status text inline (it is the acting signal).
   if (compact) {
     return (
-      <div className="flex max-w-full items-center gap-1.5 font-game">
+      // w-0 min-w-full: the hand decides how wide a seat is, never the header.
+      // A zero width box contributes nothing to the parent's intrinsic width,
+      // and min-width brings it back up to whatever the hand settled on. The
+      // status word changes on every phase ("Your Turn" to "Matching…"), and
+      // while the header could size the seat, that changed the seat's width
+      // mid turn and slid every card sideways to recentre. The name truncates
+      // instead, which nobody is trying to memorise the position of.
+      <div className="flex w-0 min-w-full items-center justify-center gap-1.5 font-game">
         {isCurrentTurn && (
           <span
             className="h-1.5 w-1.5 shrink-0 rounded-full bg-accent"
@@ -184,8 +191,9 @@ const PlayerInfoBadge = ({
   }
 
   return (
-    <div className="flex flex-col items-center gap-2 font-game">
-      <h3 className="flex items-center gap-2 text-[clamp(1rem,2.5vw,1.125rem)] font-bold text-ink">
+    // Same rule as the compact header above: the hand sets the seat's width.
+    <div className="flex w-0 min-w-full flex-col items-center gap-2 font-game">
+      <h3 className="flex max-w-full items-center gap-2 text-[clamp(1rem,2.5vw,1.125rem)] font-bold text-ink">
         {/* The one "whose turn" color on screen: an accent dot before the name. */}
         {isCurrentTurn && (
           <span className="h-1.5 w-1.5 rounded-full bg-accent" aria-hidden />

--- a/tools/probe/probe.mjs
+++ b/tools/probe/probe.mjs
@@ -41,6 +41,7 @@ const opts = {
   headed: flag("headed"),
   verbose: flag("verbose"),
   breakdown: flag("breakdown"),
+  shift: flag("shift"),
 };
 
 if (!CHECKPOINTS.includes(opts.at)) {
@@ -424,6 +425,89 @@ const report = (rows, opts) => {
 
 // ---------------------------------------------------------------------------
 
+/** Does anything move sideways when only the game's phase changed?
+ *
+ *  Nothing in a seat should. Card positions are the game's spatial memory: a
+ *  player is remembering "the nine is bottom-left", and a seat that drifts
+ *  every time a status word changes length is quietly undermining that. */
+const shiftCheck = async (page, host, observedId) => {
+  const snap = () =>
+    page.evaluate(() => {
+      const out = [];
+      for (const grid of document.querySelectorAll(".inline-grid")) {
+        const seat = grid.closest(".flex.flex-col.items-center");
+        const r = grid.getBoundingClientRect();
+        const head = seat?.firstElementChild?.getBoundingClientRect();
+        out.push({
+          who: (seat?.innerText || "").split("\n")[0]?.slice(0, 16) ?? "?",
+          handX: Math.round(r.x * 10) / 10,
+          handW: Math.round(r.width * 10) / 10,
+          headW: head ? Math.round(head.width * 10) / 10 : null,
+          cards: [...grid.children].map(
+            (c) => Math.round(c.getBoundingClientRect().x * 10) / 10,
+          ),
+        });
+      }
+      return out;
+    });
+
+  const label = () => {
+    const s = host.state;
+    return `${s?.turnPhase ?? "?"}${s?.currentPlayerId === observedId ? " (yours)" : ""}`;
+  };
+
+  const frames = [{ phase: label(), seats: await snap() }];
+  const step = async (name, fn) => {
+    await fn();
+    await page.waitForTimeout(700); // let the layout spring settle
+    frames.push({ phase: `${name} -> ${label()}`, seats: await snap() });
+  };
+
+  await step("draw", async () => {
+    await page
+      .getByRole("button", { name: /draw from deck/i })
+      .click({ timeout: 8000 })
+      .catch(() => {});
+    await host
+      .waitFor((s) => !!s.players[observedId]?.pendingDrawnCard, "drawn", 8000)
+      .catch(() => {});
+  });
+  await step("discard", async () => {
+    await page
+      .getByRole("button", { name: /discard card/i })
+      .click({ timeout: 8000 })
+      .catch(() => {});
+    await host
+      .waitFor((s) => !!s.matchingOpportunity, "matching", 8000)
+      .catch(() => {});
+  });
+
+  console.log(`\nsideways movement across phase changes\n${"-".repeat(72)}`);
+  let moved = 0;
+  const base = frames[0];
+  for (const f of frames.slice(1)) {
+    for (let i = 0; i < base.seats.length; i++) {
+      const a = base.seats[i];
+      const b = f.seats[i];
+      if (!a || !b) continue;
+      const dx = Math.round((b.handX - a.handX) * 10) / 10;
+      const dw = Math.round((b.handW - a.handW) * 10) / 10;
+      const dh = Math.round((b.headW - a.headW) * 10) / 10;
+      if (Math.abs(dx) < 0.5 && Math.abs(dw) < 0.5) continue;
+      moved++;
+      console.log(
+        `  ${f.phase.padEnd(28)} ${a.who.padEnd(12)} hand moved ${dx > 0 ? "+" : ""}${dx}px, width ${dw > 0 ? "+" : ""}${dw}px` +
+          (Math.abs(dh) >= 0.5
+            ? `  (its header changed ${dh > 0 ? "+" : ""}${dh}px)`
+            : ""),
+      );
+    }
+  }
+  if (!moved) console.log("  nothing moved");
+  console.log("");
+  return moved;
+};
+
 const main = async () => {
   await preflight();
   mkdirSync(OUT, { recursive: true });
@@ -457,6 +541,12 @@ const main = async () => {
     );
     let observedId;
     ({ bots, observedId } = await drive(page, opts));
+
+    if (opts.shift) {
+      await page.setViewportSize(viewports[0]);
+      await page.waitForTimeout(300);
+      failures += await shiftCheck(page, bots[0], observedId);
+    }
 
     // Every row has to describe the same game, or the table is comparing
     // different boards and quietly says nothing.


### PR DESCRIPTION
Closes #83.

Reported as cards shifting subtly left and right as turns move through their phases. Reproduced, measured, and fixed at the cause.

## What was happening

A seat is `flex flex-col items-center` holding a header and a hand, so its width was whichever of the two was wider. The header carries the status word, and that word changes on every phase: "Your Turn" to "Playing" to "Matching…" to "Waiting". Whenever the header was the wider of the two, a phase change resized the seat, and every card in it slid sideways to recentre.

Measured on a Pixel 5 with `--shift`:

```
discard -> MATCHING (yours)  Observed  hand moved -3.2px, width +6.4px  (its header changed +6.4px)
```

Small, constant, and on every phase change of every turn. `PlayerHandStrip` is a `motion.div` with `layout`, so it animates rather than jumps, which is why it reads as drifting rather than as a glitch.

Card positions are this game's spatial memory. The whole ask is that you remember the nine is bottom-left, and a seat that drifts each time a word changes length works against exactly that.

## The fix

The hand decides the seat's width; the header follows it.

```
w-0 min-w-full
```

A zero width box contributes nothing to the parent's intrinsic width, and `min-width` brings it back up to whatever the hand settled on. A longer status now truncates the name instead of widening the seat, and nobody is memorising where a name sits.

Applied to both headers, so it holds whether seats are compact by player count or by viewport height.

## What found it

Adds `--shift` to the probe: snapshot every seat, drive a phase change, snapshot again, report anything that moved sideways along with whether its header changed width in the same step. That last column is what turned a symptom into a cause in one run.

This is the stability probe #57 asks for, in its narrowest useful form.

## Verification

`--shift` reports `nothing moved` on all three header paths:

- phone, 2 players, compact by height
- phone, 4 players, compact by count
- desktop, 2 players, the full two-line header

The viewport fit is unchanged: board and lobby still `ok` at all seven viewports with nothing clipped and every control reachable.

## Note on cause

Part of this was mine. The compact header was previously reserved for tables of four or more, and the viewport work turned it on for every phone. Compact puts the status inline with the name rather than on its own line, which made the header the width driver far more often. The underlying fault predates that, and at a dense table it always fired, but phones felt it more after that change than before.
