### PR TITLE
fix: stop your own name truncating, and make the probe capture always

### DIFF
--- a/client/components/game/PlayerHandStrip.tsx
+++ b/client/components/game/PlayerHandStrip.tsx
@@ -143,14 +143,25 @@ const PlayerInfoBadge = ({
   // local player keeps its status text inline (it is the acting signal).
   if (compact) {
     return (
-      // w-0 min-w-full: the hand decides how wide a seat is, never the header.
-      // A zero width box contributes nothing to the parent's intrinsic width,
-      // and min-width brings it back up to whatever the hand settled on. The
-      // status word changes on every phase ("Your Turn" to "Matching…"), and
-      // while the header could size the seat, that changed the seat's width
-      // mid turn and slid every card sideways to recentre. The name truncates
-      // instead, which nobody is trying to memorise the position of.
-      <div className="flex w-0 min-w-full items-center justify-center gap-1.5 font-game">
+      // Two different jobs, so two different rules.
+      //
+      // An opponent's header is pinned to its hand's width with w-0 min-w-full:
+      // a zero width box adds nothing to the parent's intrinsic width and the
+      // min-width brings it back up to whatever the hand settled on. That keeps
+      // dense seats packing three to a phone row, which is the whole point of
+      // compact mode, and their names are secondary enough to truncate.
+      //
+      // Your own seat gets to be wider than its hand, because truncating the
+      // player's own name to "Am…" to save space nobody was using is a bad
+      // trade. Its status block is fixed width instead, which is what actually
+      // stops the drift: the word changes on every phase and a header that
+      // resizes mid turn slides every card sideways to recentre.
+      <div
+        className={cn(
+          "flex items-center justify-center gap-1.5 font-game",
+          !isLocalPlayer && "w-0 min-w-full",
+        )}
+      >
         {isCurrentTurn && (
           <span
             className="h-1.5 w-1.5 shrink-0 rounded-full bg-accent"
@@ -170,12 +181,16 @@ const PlayerInfoBadge = ({
           (isLocalPlayer ? (
             <span
               className={cn(
-                "flex shrink-0 items-center gap-1 text-[11px] font-semibold",
+                // Fixed width, wide enough for the longest status the machine
+                // produces ("Disconnected"). The status is the only part of
+                // this header whose content changes during a turn, so pinning
+                // it is what keeps the seat still.
+                "flex w-[5.5rem] shrink-0 items-center justify-center gap-1 text-[11px] font-semibold",
                 muted ? "text-ink-muted" : "text-ink",
               )}
             >
-              <Icon className="h-3 w-3" />
-              <span>{text}</span>
+              <Icon className="h-3 w-3 shrink-0" />
+              <span className="truncate">{text}</span>
             </span>
           ) : (
             <Icon
@@ -337,7 +352,12 @@ export const PlayerHandStrip: React.FC<PlayerHandStripProps> = ({
         selectedCardIndex={
           isLocalPlayer && canMatch ? matchAttempt?.cardIndex : undefined
         }
-        className="w-full max-w-md"
+        // w-fit, not w-full. The grid's tracks are 1fr and the cards inside
+        // them are a fixed width, so a hand told to fill a seat wider than
+        // itself widens its tracks and leaves the cards sitting apart. Your own
+        // seat is wider than its hand now, and the gap between your cards
+        // should not depend on how long your name is.
+        className="w-fit max-w-md"
         dense={denseCards}
       />
     </motion.div>

--- a/tools/probe/README.md
+++ b/tools/probe/README.md
@@ -39,11 +39,39 @@ and the rows stop describing the same game.
 | `--players`   | How many actually join, 2 to 6. Default 2.                                           |
 | `--seats`     | Lobby capacity. Defaults to `--players`. Six seats with two players is its own case. |
 | `--viewports` | `smoke` (default), `all`, or a comma separated list.                                 |
+| `--theme`     | `dark` (default) or `light`.                                                         |
+| `--name`      | The observed player's name. Long ones are worth trying on purpose.                   |
+| `--out`       | Where captures land. Default `.probe`.                                               |
+| `--baseline`  | An earlier `--out` directory to compare this run's captures against.                 |
+| `--shift`     | Change phase, then report anything that moved sideways.                              |
+| `--breakdown` | Itemise where the height goes, row by row.                                           |
 | `--headed`    | Watch it drive.                                                                      |
 | `--verbose`   | Dump the raw measurements.                                                           |
 
 Exit code is 1 when something fails and 2 when the probe could not run at all.
-Failure screenshots and `report.json` land in `.probe/`.
+
+## Screenshots are taken always, not only on failure
+
+This was the other way round once, and it made a run blind exactly when
+everything passed, which is when a change is most likely to have quietly made
+something ugly rather than broken. Green tells you nothing about whether a name
+now truncates to three letters.
+
+Every viewport is captured as `<at>-<players>p<seats>s-<theme>-<viewport>.png`,
+so two runs of the same command produce comparable files. Point the second run
+at the first:
+
+```
+npm run probe -- --at play --name "Ammar Hassan" --out .probe/before
+# change something
+npm run probe -- --at play --name "Ammar Hassan" --out .probe/after --baseline .probe/before
+```
+
+It reports the share of pixels that moved per shot and writes a `diff-*.png`
+marking them, so "did this touch anything it should not have" is answered
+rather than assumed.
+
+`report.json` lands beside them.
 
 ## How it is put together
 

--- a/tools/probe/package-lock.json
+++ b/tools/probe/package-lock.json
@@ -8,7 +8,9 @@
       "name": "check-probe",
       "version": "1.0.0",
       "dependencies": {
+        "pixelmatch": "^7.2.0",
         "playwright": "^1.62.1",
+        "pngjs": "^7.0.0",
         "socket.io-client": "^4.8.3"
       }
     },
@@ -77,6 +79,18 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/pixelmatch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-7.2.0.tgz",
+      "integrity": "sha512-xhcb4yHu9sM/G7foGzoLtXYcC0zHEaOXXjRKhGup0fw78Nf2Tkiapv4EQyMzrbcmQPsllAI7DbFY2UT7PlI9Pg==",
+      "license": "ISC",
+      "dependencies": {
+        "pngjs": "^7.0.0"
+      },
+      "bin": {
+        "pixelmatch": "bin/pixelmatch"
+      }
+    },
     "node_modules/playwright": {
       "version": "1.62.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
@@ -105,6 +119,15 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
       }
     },
     "node_modules/socket.io-client": {

--- a/tools/probe/package.json
+++ b/tools/probe/package.json
@@ -8,7 +8,9 @@
     "probe": "node probe.mjs"
   },
   "dependencies": {
+    "pixelmatch": "^7.2.0",
     "playwright": "^1.62.1",
+    "pngjs": "^7.0.0",
     "socket.io-client": "^4.8.3"
   }
 }

--- a/tools/probe/probe.mjs
+++ b/tools/probe/probe.mjs
@@ -10,7 +10,9 @@
 // It reports measurements. Judgement is at the bottom, in one place.
 
 import { chromium } from "playwright";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { PNG } from "pngjs";
+import pixelmatch from "pixelmatch";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { HeadlessPlayer } from "./player.mjs";
@@ -22,7 +24,6 @@ const SERVER = process.env.PROBE_SERVER_URL ?? "http://localhost:8000";
 // Anchored to the repo, not to the shell's directory, so output lands in the
 // same place whether this is run from the root or from tools/probe.
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
-const OUT = join(ROOT, ".probe");
 
 const CHECKPOINTS = ["lobby", "peek", "play", "drawn", "matching", "scoring"];
 
@@ -42,7 +43,23 @@ const opts = {
   verbose: flag("verbose"),
   breakdown: flag("breakdown"),
   shift: flag("shift"),
+  theme: arg("theme", "dark"),
+  // The observed player's name. Worth turning up deliberately: a seat's width
+  // is set by its hand, so a long name truncates rather than widening the
+  // seat, and how much it truncates is a thing to look at rather than assume.
+  name: arg("name", "Observed"),
+  out: arg("out", ".probe"),
+  // A directory of shots from an earlier run. Every capture is compared
+  // against its opposite number and the changed pixel count reported, so
+  // "did this change anything it should not have" is answered rather than
+  // hoped about.
+  baseline: arg("baseline", null),
 };
+
+if (!["dark", "light"].includes(opts.theme)) {
+  console.error(`--theme must be dark or light`);
+  process.exit(2);
+}
 
 if (!CHECKPOINTS.includes(opts.at)) {
   console.error(
@@ -141,7 +158,7 @@ const drive = async (page, opts) => {
     waitUntil: "domcontentloaded",
   });
   const dialog = page.locator('[role="dialog"]');
-  await dialog.locator("input").first().fill("Observed");
+  await dialog.locator("input").first().fill(opts.name);
   await dialog.getByRole("button", { name: /confirm and join/i }).click();
 
   await host.waitFor(
@@ -508,9 +525,31 @@ const shiftCheck = async (page, host, observedId) => {
   return moved;
 };
 
+/** Compares one capture against the same shot from an earlier run. Returns the
+ *  share of pixels that differ, or null when there is nothing to compare to. */
+const compareToBaseline = (shotPath, baselineDir, fileName, outDir) => {
+  if (!baselineDir) return null;
+  const prior = join(baselineDir, fileName);
+  if (!existsSync(prior)) return null;
+  const a = PNG.sync.read(readFileSync(prior));
+  const b = PNG.sync.read(readFileSync(shotPath));
+  if (a.width !== b.width || a.height !== b.height) return { resized: true };
+  const diff = new PNG({ width: a.width, height: a.height });
+  const changed = pixelmatch(a.data, b.data, diff.data, a.width, a.height, {
+    threshold: 0.1,
+  });
+  const share = changed / (a.width * a.height);
+  if (changed > 0) {
+    writeFileSync(join(outDir, `diff-${fileName}`), PNG.sync.write(diff));
+  }
+  return { changed, share };
+};
+
 const main = async () => {
   await preflight();
+  const OUT = join(ROOT, opts.out);
   mkdirSync(OUT, { recursive: true });
+  const shots = [];
 
   const viewports = resolveViewports(opts.viewports);
   const browser = await chromium.launch({ headless: !opts.headed });
@@ -525,6 +564,14 @@ const main = async () => {
     viewport: { width: 1600, height: 1200 },
     deviceScaleFactor: 1,
   });
+  // next-themes reads its choice from localStorage before paint, so it has to
+  // be there before the first navigation or the run silently shoots whichever
+  // theme happens to be the default.
+  await context.addInitScript((theme) => {
+    try {
+      localStorage.setItem("theme", theme);
+    } catch {}
+  }, opts.theme);
   const page = await context.newPage();
 
   const consoleErrors = [];
@@ -565,12 +612,16 @@ const main = async () => {
       const m = await page.evaluate(measureInPage);
       rows.push({ viewport, m });
 
-      const unreachable = m.controls.some((c) => c.status !== "ok");
-      if (unreachable || m.scrollers.length) {
-        await page.screenshot({
-          path: join(OUT, `${opts.at}-${viewport.name}.png`),
-        });
-      }
+      // Always, not only on failure. Capturing only failures leaves the run
+      // visually blind exactly when everything passes, which is when a fix is
+      // most likely to have quietly made something ugly rather than broken.
+      const fileName = `${opts.at}-${opts.players}p${opts.seats}s-${opts.theme}-${viewport.name}.png`;
+      const shotPath = join(OUT, fileName);
+      await page.screenshot({ path: shotPath });
+      shots.push({
+        fileName,
+        diff: compareToBaseline(shotPath, opts.baseline, fileName, OUT),
+      });
     }
 
     const after = stamp();
@@ -582,9 +633,32 @@ const main = async () => {
     }
 
     failures = report(rows, opts);
+
+    console.log(`${shots.length} shots (${opts.theme}) -> ${OUT}`);
+    if (opts.baseline) {
+      const compared = shots.filter((s) => s.diff);
+      const moved = compared.filter((s) => s.diff.resized || s.diff.changed);
+      if (!compared.length) {
+        console.log(`  nothing in ${opts.baseline} to compare against`);
+      } else if (!moved.length) {
+        console.log(
+          `  pixel identical to ${opts.baseline} (${compared.length} shots)`,
+        );
+      } else {
+        console.log(`  changed against ${opts.baseline}:`);
+        for (const s of moved) {
+          console.log(
+            s.diff.resized
+              ? `    ${s.fileName}  different dimensions`
+              : `    ${s.fileName}  ${(s.diff.share * 100).toFixed(2)}% of pixels (diff-${s.fileName})`,
+          );
+        }
+      }
+    }
+
     writeFileSync(
       join(OUT, "report.json"),
-      JSON.stringify({ opts, rows, consoleErrors }, null, 2),
+      JSON.stringify({ opts, rows, shots, consoleErrors }, null, 2),
     );
     console.log(`detail -> ${join(OUT, "report.json")}`);
 


### PR DESCRIPTION
Two visual regressions from #88, plus the probe change that made them visible.

## The probe was blind when it passed

It only captured a screenshot on failure. So the moment everything went green it stopped producing any visual record at all, which is exactly when a change is most likely to have quietly made something ugly rather than broken. Every check in #88 was green and both of the bugs below were sitting there.

It now captures every viewport every run, as `<at>-<players>p<seats>s-<theme>-<viewport>.png`, so two runs of the same command are comparable. `--baseline <dir>` diffs this run against an earlier one with pixelmatch and reports the share of pixels that moved, writing a `diff-*.png` for each. Also adds `--theme dark|light` and `--name`, since neither was reachable before and both matter: I had never once looked at this game in its light palette.

## Your own name truncated to three letters

#88 pinned every seat header to its hand's width, 126px on a phone. The header is a dot, a name and a status; the status takes about 90px of that, leaving roughly 37px for the name. "Ammar Hassan" rendered as **"Am…"**.

Trading a 3px drift for an unreadable name is not a trade.

Two headers now get two rules. An **opponent's** stays pinned to its hand, because that is what keeps dense seats packing three to a phone row, and opponent names are secondary enough to truncate. **Your own** may be wider than its hand, and its status block is fixed width instead. That is what actually stops the drift, and it is more precise than what #88 did: the status is the only part of the header whose content changes during a turn.

## Your cards sat further apart than everyone else's

Consequence of the above, caught in the same screenshot. `HandGrid` is `1fr` tracks around fixed-width cards, so a hand told to fill a seat wider than itself widens its tracks and spreads the cards. Once your seat could exceed its hand, your two columns drifted apart while every opponent's stayed tight.

`w-fit` rather than `w-full`. The gap between your cards should not depend on how long your name is.

## Verification

- `--shift` still reports `nothing moved`, so #88's fix holds.
- All seven viewports still fit with nothing clipped and every control reachable, at 2 and 4 players.
- Looked at, not just measured: 393x745 dark with a twelve character name, and 4 players light where the dense three-per-row band is in play.

Neither of these was visible to any measurement. Both were obvious in a screenshot.
