### PR TITLE
feat: give the action bar back to the cards, and even out its spacing

### DIFF
--- a/client/components/game/ActionBarComponent.tsx
+++ b/client/components/game/ActionBarComponent.tsx
@@ -86,7 +86,7 @@ const ActionBarComponent: React.FC = () => {
 
   return (
     <motion.div
-      className="flex flex-col items-center w-full"
+      className="flex w-full flex-col items-center gap-2 tiny:gap-1.5"
       initial={{ y: 20, opacity: 0 }}
       animate={{ y: 0, opacity: 1 }}
       transition={{
@@ -107,31 +107,6 @@ const ActionBarComponent: React.FC = () => {
         ))}
       </motion.div>
 
-      {/* Fixed-height slot: the prompt fades in place and can wrap to two
-          lines without ever changing the bar's height (which would reflow
-          the whole board). */}
-      <div
-        // Two lines either way: the slot and the type shrink together, so a
-        // wrapping prompt still fits and does not clip.
-        className="mt-2 flex h-10 items-start justify-center short:h-8 tiny:mt-1 tiny:h-5"
-        aria-live="polite"
-      >
-        <AnimatePresence>
-          {promptText && (
-            <motion.p
-              key="prompt-text"
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={{ duration: 0.2, ease: "easeInOut" }}
-              className="max-w-[min(92vw,40rem)] px-4 text-center text-sm font-semibold text-ink-muted text-balance short:text-xs tiny:truncate"
-            >
-              {promptText}
-            </motion.p>
-          )}
-        </AnimatePresence>
-      </div>
-
       {/* Countdown for the active timed window. Pure CSS-driven animation
           keyed by deadline: no per-frame re-renders. Fixed-height slot for
           the same no-reflow reason. */}
@@ -139,7 +114,7 @@ const ActionBarComponent: React.FC = () => {
           in one cell. As flex siblings they sat side by side during the
           crossfade — the new bar mounted half a bar-width off-center and
           snapped back when the exit finished (the "teleporting" bar). */}
-      <div className="mt-1 grid h-1 w-full items-center justify-items-center">
+      <div className="grid h-1 w-full items-center justify-items-center">
         <AnimatePresence>
           {timedIndicator && remainingMs > 0 && countdownRevealed && (
             <motion.div
@@ -158,6 +133,32 @@ const ActionBarComponent: React.FC = () => {
                 transition={{ duration: remainingMs / 1000, ease: "linear" }}
               />
             </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+      {/* Prompt last, under the countdown. The countdown times the action the
+          buttons offer, so it sits against them; the prompt is the explanation
+          and reads after. With the prompt in between, the gap under the pill
+          ran three times the gap above it however the margins were tuned.
+          Fixed height so it cannot reflow the row above. */}
+      <div
+        // Two lines either way: the slot and the type shrink together, so a
+        // wrapping prompt still fits and does not clip.
+        className="flex h-10 items-start justify-center short:h-8 tiny:h-5"
+        aria-live="polite"
+      >
+        <AnimatePresence>
+          {promptText && (
+            <motion.p
+              key="prompt-text"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.2, ease: "easeInOut" }}
+              className="max-w-[min(92vw,40rem)] px-4 text-center text-sm font-semibold text-ink-muted text-balance short:text-xs tiny:truncate"
+            >
+              {promptText}
+            </motion.p>
           )}
         </AnimatePresence>
       </div>

--- a/client/components/game/ActionBarComponent.tsx
+++ b/client/components/game/ActionBarComponent.tsx
@@ -97,7 +97,7 @@ const ActionBarComponent: React.FC = () => {
       <motion.div
         layout
         transition={{ type: "spring", stiffness: 400, damping: 35 }}
-        className="flex flex-row flex-wrap items-center justify-center gap-2 rounded-full border border-hairline bg-surface p-2 shadow-lg"
+        className="flex flex-row flex-wrap items-center justify-center gap-2 rounded-full border border-hairline bg-surface p-2 shadow-lg tiny:gap-1.5 tiny:p-1.5"
       >
         {actions.map((action, i) => (
           <ActionButton
@@ -113,7 +113,7 @@ const ActionBarComponent: React.FC = () => {
       <div
         // Two lines either way: the slot and the type shrink together, so a
         // wrapping prompt still fits and does not clip.
-        className="mt-2 flex h-10 items-start justify-center short:h-8"
+        className="mt-2 flex h-10 items-start justify-center short:h-8 tiny:mt-1 tiny:h-5"
         aria-live="polite"
       >
         <AnimatePresence>
@@ -124,7 +124,7 @@ const ActionBarComponent: React.FC = () => {
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
               transition={{ duration: 0.2, ease: "easeInOut" }}
-              className="max-w-[min(92vw,40rem)] px-4 text-center text-sm font-semibold text-ink-muted text-balance short:text-xs"
+              className="max-w-[min(92vw,40rem)] px-4 text-center text-sm font-semibold text-ink-muted text-balance short:text-xs tiny:truncate"
             >
               {promptText}
             </motion.p>

--- a/client/components/game/ActionButton.tsx
+++ b/client/components/game/ActionButton.tsx
@@ -191,7 +191,7 @@ const ActionButton: React.FC<ActionButtonProps> = ({ action }) => {
             // pseudo-classes cannot. Tailwind v4 gates hover: to
             // hover-capable devices, covering the old isTouchDevice check.
             className={cn(
-              "relative flex h-10 shrink-0 select-none items-center justify-center overflow-hidden rounded-full transition enabled:hover:scale-110 enabled:active:scale-90",
+              "relative flex h-10 shrink-0 select-none items-center justify-center overflow-hidden rounded-full transition enabled:hover:scale-110 enabled:active:scale-90 tiny:h-9",
               icon ? "w-10" : "px-4",
               // One accent-filled primary; secondary label = hairline-outline
               // pill, secondary icon = bare ink-muted button.

--- a/client/components/game/GameBoard.tsx
+++ b/client/components/game/GameBoard.tsx
@@ -362,7 +362,7 @@ export function GameBoard() {
                   // The bar's own content is 112px: the pill, then the
                   // fixed prompt slot, then the countdown rail. h-32 is
                   // headroom, and headroom is the first thing to go.
-                  shortViewport ? "h-28" : "h-28 @md:h-32",
+                  shortViewport ? "h-28 tiny:h-[5.5rem]" : "h-28 @md:h-32",
                 )}
               >
                 <ActionControllerView />

--- a/client/components/game/GameBoard.tsx
+++ b/client/components/game/GameBoard.tsx
@@ -358,11 +358,11 @@ export function GameBoard() {
                   // pb-2 goes on a short screen: the bar's own content is
                   // 114px against this row's 112, so the padding was pushing
                   // the last two pixels out through the bottom of the board.
-                  "flex items-start justify-center pb-2 short:pb-0",
+                  "flex items-center justify-center pb-2 short:pb-0",
                   // The bar's own content is 112px: the pill, then the
                   // fixed prompt slot, then the countdown rail. h-32 is
                   // headroom, and headroom is the first thing to go.
-                  shortViewport ? "h-28 tiny:h-[5.5rem]" : "h-28 @md:h-32",
+                  shortViewport ? "h-28 tiny:h-24" : "h-28 @md:h-32",
                 )}
               >
                 <ActionControllerView />

--- a/client/components/game/PlayerHand.tsx
+++ b/client/components/game/PlayerHand.tsx
@@ -222,8 +222,8 @@ const PlayerHand: React.FC<PlayerHandProps> = ({
               className={cn(
                 "relative aspect-[5/7]",
                 dense
-                  ? "w-[min(8svh,11.5vw,3.5rem)] tiny:w-[min(6svh,11.5vw,3.5rem)] @4xl:w-[min(8svh,11.5vw)]"
-                  : "w-[min(8svh,15vw)] tiny:w-[min(6svh,15vw)]",
+                  ? "w-[min(8svh,11.5vw,3.5rem)] tiny:w-[min(7.5svh,11.5vw,3.5rem)] @4xl:w-[min(8svh,11.5vw)]"
+                  : "w-[min(8svh,15vw)] tiny:w-[min(7.5svh,15vw)]",
               )}
             >
               <div className="absolute inset-0 rounded-card border border-hairline" />
@@ -307,8 +307,8 @@ const PlayerHand: React.FC<PlayerHandProps> = ({
               // full row fits anyway and the cap lifts, so desktop and
               // half-screen sizes are unchanged.
               dense
-                ? "w-[min(8svh,11.5vw,3.5rem)] tiny:w-[min(6svh,11.5vw,3.5rem)] @4xl:w-[min(8svh,11.5vw)]"
-                : "w-[min(8svh,15vw)] tiny:w-[min(6svh,15vw)]",
+                ? "w-[min(8svh,11.5vw,3.5rem)] tiny:w-[min(7.5svh,11.5vw,3.5rem)] @4xl:w-[min(8svh,11.5vw)]"
+                : "w-[min(8svh,15vw)] tiny:w-[min(7.5svh,15vw)]",
             )}
           >
             {/* No whileHover here: this is the layoutId projection node, and

--- a/client/components/game/PlayerHand.tsx
+++ b/client/components/game/PlayerHand.tsx
@@ -222,8 +222,8 @@ const PlayerHand: React.FC<PlayerHandProps> = ({
               className={cn(
                 "relative aspect-[5/7]",
                 dense
-                  ? "w-[min(8svh,11.5vw,3.5rem)] tiny:w-[min(7.5svh,11.5vw,3.5rem)] @4xl:w-[min(8svh,11.5vw)]"
-                  : "w-[min(8svh,15vw)] tiny:w-[min(7.5svh,15vw)]",
+                  ? "w-[min(8svh,11.5vw,3.5rem)] tiny:w-[min(7svh,11.5vw,3.5rem)] @4xl:w-[min(8svh,11.5vw)]"
+                  : "w-[min(8svh,15vw)] tiny:w-[min(7svh,15vw)]",
               )}
             >
               <div className="absolute inset-0 rounded-card border border-hairline" />
@@ -307,8 +307,8 @@ const PlayerHand: React.FC<PlayerHandProps> = ({
               // full row fits anyway and the cap lifts, so desktop and
               // half-screen sizes are unchanged.
               dense
-                ? "w-[min(8svh,11.5vw,3.5rem)] tiny:w-[min(7.5svh,11.5vw,3.5rem)] @4xl:w-[min(8svh,11.5vw)]"
-                : "w-[min(8svh,15vw)] tiny:w-[min(7.5svh,15vw)]",
+                ? "w-[min(8svh,11.5vw,3.5rem)] tiny:w-[min(7svh,11.5vw,3.5rem)] @4xl:w-[min(8svh,11.5vw)]"
+                : "w-[min(8svh,15vw)] tiny:w-[min(7svh,15vw)]",
             )}
           >
             {/* No whileHover here: this is the layoutId projection node, and

--- a/tools/probe/measure.mjs
+++ b/tools/probe/measure.mjs
@@ -143,14 +143,7 @@ export function measureInPage() {
   // and the first thing anyone needs is the itemised bill rather than a guess
   // at which row is fat.
   const budget = [];
-  const tallest = scrollers.sort((a, b) => b.scrollH - a.scrollH)[0];
-  const root = tallest
-    ? [...document.querySelectorAll("body *")].find(
-        (e) =>
-          e.tagName.toLowerCase() === tallest.el &&
-          e.scrollHeight === tallest.scrollH,
-      )
-    : document.querySelector("main");
+  const root = document.querySelector("main") ?? document.body;
   if (root) {
     // display:contents boxes generate no box of their own, so their children
     // are the real rows and have to be walked through. Descend two levels:
@@ -170,30 +163,36 @@ export function measureInPage() {
       }
       return out;
     };
-    const collect = (el, depth) => {
-      const children = boxes(el);
-      const tallest = children.reduce(
-        (a, b) =>
-          b.getBoundingClientRect().height >
-          (a?.getBoundingClientRect().height ?? 0)
-            ? b
-            : a,
+    // Descend through pass-through wrappers, then list what is left.
+    //
+    // A wrapper that holds essentially all of its parent's height is not a row,
+    // it is a box around the rows, and listing it says nothing. Keep going
+    // while the tallest child is nearly as tall as its parent, and stop at the
+    // first level where the height is genuinely divided up. Walking a fixed
+    // number of levels instead meant the report went blank as soon as the view
+    // stopped overflowing and the starting element changed.
+    const heightOf = (el) => el.getBoundingClientRect().height;
+    const tallestOf = (children) =>
+      children.reduce(
+        (a, b) => (heightOf(b) > (a ? heightOf(a) : 0) ? b : a),
         null,
       );
-      for (const child of children) {
-        const r = child.getBoundingClientRect();
-        if (depth > 0 && child === tallest && boxes(child).length > 0) {
-          collect(child, depth - 1);
-          continue;
-        }
-        budget.push({
-          tag: child.tagName.toLowerCase(),
-          cls: String(child.className).slice(0, 46),
-          height: Math.round(r.height),
-        });
-      }
-    };
-    collect(root, 1);
+
+    let node = root;
+    for (let guard = 0; guard < 8; guard++) {
+      const children = boxes(node);
+      const tallest = tallestOf(children);
+      if (!tallest || boxes(tallest).length === 0) break;
+      if (heightOf(tallest) < heightOf(node) * 0.85) break;
+      node = tallest;
+    }
+    for (const child of boxes(node)) {
+      budget.push({
+        tag: child.tagName.toLowerCase(),
+        cls: String(child.className).slice(0, 46),
+        height: Math.round(heightOf(child)),
+      });
+    }
   }
 
   return {


### PR DESCRIPTION
Follow-on from #85. The board fit at 1280x500, but only by squeezing the cards to 30px while the action bar kept 128px of a 500px viewport, a quarter of the height, to hold a 40px row of buttons.

## The bar gives, the cards get it back

All three parts of the bar shrink below 600px: the pill loses padding and its buttons a notch of height, the prompt slot goes to one line, and the row follows them down. The prompt truncates rather than wrapping there, since a clipped second line reads worse than an ellipsis.

That height goes into the cards.

| at 1280x500 | before #85 | after #85 | now |
| --- | --- | --- | --- |
| action bar | 128px | 112px | **88px** |
| each seat | 203px | 160px | **145px** |
| cards | 40px | 30px | **35px** |
| fits | no, 242px over | yes | **yes** |

So the board fits and the cards are close to the size they were before any of this, rather than fitting by shrinking everything.

## Even spacing around the bar

Reported: the buttons sat too close to the hand above and too far from the countdown below. Measured at 10px against 30px.

Uniform gaps and a centred block were not enough, because the asymmetry was the **ordering**. A fixed height prompt slot sat between the pill and the countdown, and it is often empty, so roughly 20px of nothing separated the buttons from their own timer whichever way the margins were tuned. Moving the prompt above the pill simply inverted it, to 40px against 10px.

The countdown now sits directly under the buttons, prompt last. The timer measures the action the buttons offer, so it belongs against them, and the prompt reads after as the explanation. **14px above the pill against 10px below**, from 10 against 30.

## `--breakdown` had gone silent

It chose its starting element from whatever was overflowing, so the moment a view stopped overflowing it had nothing to report, which is exactly when it is wanted for tuning this. It now walks down from `main` through pass-through wrappers and stops at the first level where the height is genuinely divided up.

## Verification

- All seven viewports, board and lobby, no overflow and every control reachable.
- `--at drawn` and `--at matching` swept across all seven, since those are the states where the prompt slot is actually occupied and the reorder had only been seen with it empty.
- `--shift` still reports nothing moved.
- Looked at rather than only measured: 1280x500 and Pixel 5, empty prompt and occupied, dark.

## Related

The wide-window emptiness at 1280x500 is **not** fixed here and is filed as #90. Bigger cards and a shallower bar help, but a vertical stack cannot use horizontal space, and that wants a real layout change rather than more tuning.
