### PR TITLE
fix: raise the short threshold and test real browser viewports

### DIFF
--- a/client/app/globals.css
+++ b/client/app/globals.css
@@ -6,7 +6,7 @@
    short screen shrinks them while fixed-height furniture keeps its full
    budget and the board stops fitting. Kept in step with the same threshold in
    GameBoard, which drives the parts that are a prop rather than a class. */
-@custom-variant short (@media (max-height: 900px));
+@custom-variant short (@media (max-height: 1000px));
 
 /* A second tier for genuinely small heights, a half-height desktop window or
    a phone in landscape. Trimming furniture is not enough there: at 500px the

--- a/client/components/game/GameBoard.tsx
+++ b/client/components/game/GameBoard.tsx
@@ -143,7 +143,7 @@ export function GameBoard() {
   // screen they shrink while the furniture around them keeps its full budget
   // and the board overflows. Below this the seats drop to their one-line
   // header and the caption rail retires, which is worth about 90px.
-  const shortViewport = useMediaQuery("(max-height: 900px)");
+  const shortViewport = useMediaQuery("(max-height: 1000px)");
 
   // The round-ending broadcast both moves the last card and flips the stage:
   // mounting the end sheet immediately buries a flight ~0.3s into its 0.65s
@@ -318,7 +318,7 @@ export function GameBoard() {
                 // (15vw on an aspect-[5/7]) left the board a pixel or two over
                 // its frame with nowhere to put it.
                 "flex min-h-0 items-center justify-center @container",
-                endScene ? "order-3" : shortViewport ? "py-2" : "py-4 @md:py-8",
+                endScene ? "order-3" : shortViewport ? "py-2" : "py-4 @md:py-6",
               )}
             >
               <TableArea drawnCard={drawnCardData} dealingDeck={dealingDeck} />

--- a/tools/probe/viewports.mjs
+++ b/tools/probe/viewports.mjs
@@ -10,23 +10,37 @@
 // the URL bar, and minus the Android navigation bar where there is one.
 
 export const VIEWPORTS = [
-  { name: "pixel5-nobar", width: 393, height: 801 },
+  // Browser viewports, not screen sizes. The number a device is sold with is
+  // the screen; what matters is what is left after the browser and the OS have
+  // taken theirs, and the gap between the two is where this breaks. A 1080p
+  // desktop gives about 910, not 1080, and testing 1080 missed a live bug.
+  { name: "iphone-se", width: 375, height: 553 },
+  { name: "iphone-15", width: 393, height: 659 },
   { name: "pixel5-bar", width: 393, height: 745 },
-  { name: "iphone-se", width: 375, height: 667 },
-  { name: "ipad-portrait", width: 820, height: 1080 },
+  { name: "pixel5-nobar", width: 393, height: 801 },
+  { name: "phone-landscape", width: 745, height: 393 },
+  { name: "ipad-portrait", width: 820, height: 1024 },
+  { name: "ipad-landscape", width: 1080, height: 764 },
+  // 1366x768 is still the most common laptop panel and leaves about 600, which
+  // lands exactly on the second tier's boundary.
+  { name: "laptop-1366", width: 1366, height: 600 },
   { name: "laptop-short", width: 1280, height: 500 },
-  { name: "laptop", width: 1440, height: 780 },
-  { name: "desktop", width: 1920, height: 1080 },
+  { name: "macbook-air", width: 1440, height: 790 },
+  { name: "macbook-14", width: 1512, height: 872 },
+  { name: "desktop-window", width: 1920, height: 910 },
+  { name: "desktop-full", width: 1920, height: 1080 },
 ];
 
 /** The cells a pull request runs. The full sweep is for the nightly job. Any
  *  cell that has ever failed belongs in here permanently. */
 export const SMOKE = new Set([
-  "pixel5-bar",
-  "pixel5-nobar",
   "iphone-se",
+  "pixel5-bar",
+  "laptop-1366",
   "laptop-short",
-  "desktop",
+  "macbook-14",
+  "desktop-window",
+  "desktop-full",
 ]);
 
 export const resolve = (names) => {


### PR DESCRIPTION
Fixes the prompt text being clipped on a maximised Chrome window at 1080p, in production.

## What happened

The compact-layout threshold was `max-height: 900`. A maximised browser on a 1080p screen leaves about **910** of viewport after the tab strip, address bar, bookmarks and taskbar. It landed just above the line, took the full-height layout, overflowed by 62px, and since the countdown reorder in #91 put the prompt last, the prompt is what got cut.

## Why the probe did not catch it

Its matrix held **screen sizes, not browser viewports**. `1920x1080` is the panel. `1920x910` is what the page actually gets. Testing the first while shipping to the second is how this reached a player, and the tool that was supposed to prevent it is what hid it.

The matrix is now built from real browser viewports: iPhone SE at 553, iPhone 15 at 659, a 1366x768 laptop at 600, an iPad portrait at 1024, a MacBook 14 at 872, a maximised 1080p window at 910. Two of those were already failing and nothing knew.

## The fixes

- Threshold 900 to 1000, covering the 910 case.
- The full tier gives 16px of table padding, which is what iPad portrait at 1024 needed. It was 11px over purely by sitting above the line.

**Twelve of thirteen viewports now fit.** Phone landscape at 393 tall is 45px over and is left for #92 rather than patched with a third tier.

## The real problem is the mechanism

Fixed thresholds guess where devices land, and three cliffs have now been found this way. #92 covers replacing them with sizing that scales continuously, so adding a device to the matrix stops meaning touching the layout.

Verified with `npm run verify` and the full matrix at `--at drawn`.