### PR TITLE
fix: make a full table fit a phone

### DIFF
--- a/client/app/globals.css
+++ b/client/app/globals.css
@@ -13,7 +13,7 @@
    cards are already the smaller of 8svh and 15vw, and 8svh has won, so the
    card scale itself has to come down. Above this, 15vw is the binding limit
    and nothing here changes what a phone renders. */
-@custom-variant tiny (@media (max-height: 600px));
+@custom-variant tiny (@media (max-height: 700px));
 
 /* ============================================================================
    Design tokens — "The Clean One, multiplayer" (Round 4 visual identity)

--- a/client/components/game/GameBoard.tsx
+++ b/client/components/game/GameBoard.tsx
@@ -255,7 +255,7 @@ export function GameBoard() {
             {/* Opponents area */}
             <div
               className={cn(
-                "flex justify-center items-center py-2 tiny:py-1",
+                "flex justify-center items-center py-2 tiny:py-0.5",
                 endScene && "order-1",
               )}
             >
@@ -329,7 +329,7 @@ export function GameBoard() {
                 collapses) rather than duplicating the hand. */}
             <div
               className={cn(
-                "flex flex-col items-center justify-center py-2 tiny:py-1",
+                "flex flex-col items-center justify-center py-2 tiny:py-0.5",
                 endScene && "order-2",
               )}
             >
@@ -343,7 +343,12 @@ export function GameBoard() {
                   isCurrentTurn={isMyTurn}
                   tableIndex={opponentPlayers.length}
                   compact={compactSeats}
-                  denseCards={false}
+                  // Your own hand stays regular size, because it is the one
+                  // you act on. The exception is a crowded table on a short
+                  // screen: at six players a phone cannot afford both a
+                  // wrapped opponent band and a full size hand, and a hand
+                  // that does not fit is worse than a smaller one.
+                  denseCards={denseBand && shortViewport}
                 />
               ) : null}
             </div>

--- a/client/components/game/GameHeader.tsx
+++ b/client/components/game/GameHeader.tsx
@@ -84,7 +84,7 @@ export const GameHeader = () => {
   };
 
   return (
-    <header className="relative z-20 flex h-14 shrink-0 items-center justify-between border-b border-hairline bg-ground px-4 font-game short:h-12 md:px-6">
+    <header className="relative z-20 flex h-14 shrink-0 items-center justify-between border-b border-hairline bg-ground px-4 font-game short:h-12 tiny:h-11 md:px-6">
       <div className="flex min-w-0 items-center gap-3">
         <Link
           href="/"

--- a/client/components/game/PlayerHand.tsx
+++ b/client/components/game/PlayerHand.tsx
@@ -222,7 +222,7 @@ const PlayerHand: React.FC<PlayerHandProps> = ({
               className={cn(
                 "relative aspect-[5/7]",
                 dense
-                  ? "w-[min(8svh,11.5vw,3.5rem)] tiny:w-[min(7svh,11.5vw,3.5rem)] @4xl:w-[min(8svh,11.5vw)]"
+                  ? "w-[min(6.5svh,9.5vw,3.5rem)] tiny:w-[min(5.5svh,9.5vw,3.5rem)] @4xl:w-[min(8svh,11.5vw)]"
                   : "w-[min(8svh,15vw)] tiny:w-[min(7svh,15vw)]",
               )}
             >
@@ -307,7 +307,7 @@ const PlayerHand: React.FC<PlayerHandProps> = ({
               // full row fits anyway and the cap lifts, so desktop and
               // half-screen sizes are unchanged.
               dense
-                ? "w-[min(8svh,11.5vw,3.5rem)] tiny:w-[min(7svh,11.5vw,3.5rem)] @4xl:w-[min(8svh,11.5vw)]"
+                ? "w-[min(6.5svh,9.5vw,3.5rem)] tiny:w-[min(5.5svh,9.5vw,3.5rem)] @4xl:w-[min(8svh,11.5vw)]"
                 : "w-[min(8svh,15vw)] tiny:w-[min(7svh,15vw)]",
             )}
           >


### PR DESCRIPTION
A six player game did not fit a phone at all. The height sweep found it failing at **every height up to 800** at 393 wide, 145px over at worst, which means a Pixel 5 with the address bar showing could not display a full table.

Two player games fit, which is why every check up to now had passed.

## Four changes, each measured

**Your own hand goes dense on a crowded short screen.** It stays regular size everywhere else, because it is the one you act on, but at six players a phone cannot afford a wrapped opponent band and a full size hand at once. 800 to 760.

**Dense cards bind on height as well as width.** They were `min(8svh, 11.5vw)`, and at phone widths the `vw` term always won, so they stopped shrinking as the screen got shorter and the band kept its full height on a small phone. Now `min(6.5svh, 9.5vw)`. 760 to 680, then the remaining band collapsed.

**The second tier moves from 600 to 700.** The sweep reported `600 to 680` failing while `400 to 580` and `700` up passed. That is a tier boundary drawn in the data rather than guessed at, and it is #92 demonstrating itself.

**Seat padding and the header** give a few pixels at the smallest tier, closing a 12px and then a 4px remainder.

## Result

Swept at 2, 4 and 6 players across 393, 820, 1440 and 1920 wide, 172 viewports each:

| players | fails below |
| --- | --- |
| 2 | 460 |
| 4 | 380 |
| 6 | 380 |

**It fits at every height from 460 up.** Below that is landscape phones and nothing else, which #92 covers.

## Worth recording

**Two players is the worst case at low heights, not six.** Two never triggers dense seats, so its cards stay full size while a crowded table's shrink. The assumption was the other way round, and only sweeping every count found it.