### PR TITLE
fix: stop the probe calling a scrolling panel a failure

### DIFF
--- a/tools/probe/measure.mjs
+++ b/tools/probe/measure.mjs
@@ -38,8 +38,14 @@ export function measureInPage() {
     // own corner radius with overflow-hidden and that is not a layout failure;
     // a box tall enough to be a view is a different matter. A scrollbar at any
     // size still counts, because a game view should have none at all.
-    const isView = el.getBoundingClientRect().height >= vh * 0.6;
-    if ((scrolls || (clips && isView)) && over > 0 && visible(el, style)) {
+    // A view may not scroll. A panel inside one may.
+    //
+    // The results sheet is capped at half the viewport and scrolls its own
+    // rows on purpose, which is ordinary for a panel listing six players. Only
+    // something the size of the view itself is a fit failure, so the test is
+    // whether this box IS the view rather than merely whether it scrolls.
+    const isView = el.getBoundingClientRect().height >= vh * 0.85;
+    if ((scrolls || clips) && isView && over > 0 && visible(el, style)) {
       // Which descendant actually reaches furthest down. Summing the rows does
       // not always find it: an out-of-flow child still counts toward scrollable
       // overflow, so the rows can add up to exactly the frame while the box
@@ -94,10 +100,23 @@ export function measureInPage() {
     // under the fold is still a button a thumb misses.
     const whole = r.top >= 0 && r.bottom <= vh && r.left >= 0 && r.right <= vw;
 
+    // A control below the fold of a panel that scrolls is reachable: the panel
+    // is meant to be scrolled. Only a control the view itself cannot reach is
+    // a failure.
+    let inScrollablePanel = false;
+    for (let p = el.parentElement; p; p = p.parentElement) {
+      const ps = getComputedStyle(p);
+      if (!/auto|scroll/.test(ps.overflowY + ps.overflow)) continue;
+      if (p.getBoundingClientRect().height < vh * 0.85) {
+        inScrollablePanel = true;
+      }
+      break;
+    }
+
     let status = "ok";
     let blockedBy = null;
     if (!inViewport) {
-      status = "offscreen";
+      status = inScrollablePanel ? "ok" : "offscreen";
     } else if (!hit) {
       status = "no-hit";
     } else if (hit !== el && !el.contains(hit)) {


### PR DESCRIPTION
The probe flagged any element whose content exceeded it, which caught the results sheet doing exactly what it is built to do: it is capped at `max-h-[50vh]` and scrolls its own rows on purpose.

The no-scroll rule is about the **gameplay view**, the thing you operate while playing, not every panel in the app. A panel listing six players' scores that scrolls is ordinary.

So the check narrows:

- A scroller is a failure only when it **is** the view, at 85% of viewport height or more.
- A control below the fold of a scrollable panel counts as reachable, because scrolling that panel is how you reach it.

The gameplay view still reports its real failures unchanged, verified by re-sweeping: `2p drawn` still reports the same `360-440` band it did before.

Closes #87, which this measurement error produced. What actually matters at the end of a round is whether the revealed hands fit above the panel, since the panel overlays the bottom and cannot be minimised. Checked by screenshot at six players: they do, at 1920x910 and at 393x745. The deck and discard tucking under the panel is deliberate and documented in `GameBoard.tsx`.

Also worth recording: a screenshot at scoring taken 1800ms after the stage flips catches the reveal mid-animation, some hands face down and others mid-flip. That is the stagger, not a redaction bug.