### PR TITLE
fix: give the event caption its own threshold

### DIFF
--- a/client/app/globals.css
+++ b/client/app/globals.css
@@ -15,6 +15,12 @@
    and nothing here changes what a phone renders. */
 @custom-variant tiny (@media (max-height: 700px));
 
+/* Dropping the event caption is a content decision, not a sizing one, so it
+   gets its own line rather than riding along with the compact seats. Bundled
+   into `short` it vanished from every normal desktop, which has room for it:
+   a maximised browser at 1080p leaves 910, and the board uses 862 of that. */
+@custom-variant cramped (@media (max-height: 820px));
+
 /* ============================================================================
    Design tokens — "The Clean One, multiplayer" (Round 4 visual identity)
    Four roles per theme: ground / surface / ink / accent (+ surface-2,

--- a/client/components/game/GameEventCaption.tsx
+++ b/client/components/game/GameEventCaption.tsx
@@ -95,7 +95,7 @@ export const GameEventCaption = () => {
       // this row shifts every row up a track: the local hand inherits the 1fr
       // and the table gets squeezed into an auto. Zero height keeps the
       // mapping and still gives the height back.
-      className="flex h-8 items-center justify-center overflow-hidden font-game short:h-0"
+      className="flex h-8 items-center justify-center overflow-hidden font-game cramped:h-0"
       aria-live="polite"
     >
       <AnimatePresence mode="wait">


### PR DESCRIPTION
Raising the compact threshold from 900 to 1000 in #93 fixed the clipped prompt on a maximised 1080p window, and quietly took the event caption rail with it.

That tier bundles two unrelated things: **compact seats** and **dropping the caption**. So every normal desktop lost its match, penalty and reshuffle announcements as a side effect of a fit fix, and it was not mentioned because it was not noticed.

At 910, the most common desktop viewport:

| | before | after |
| --- | --- | --- |
| caption rail | gone | 32px, present |
| board total | 862 in a 910 frame | 862 in a 910 frame |

There was 48px spare the whole time. The rail is 32.

Dropping the caption is a content decision rather than a sizing one, so it gets its own variant and goes at 820, which is where there genuinely is no room for it. The `1fr` table row absorbs the difference.

Swept at 2 and 6 players across four widths: failing bands unchanged at `360-440` and `360`, so nothing was traded for it.

Same class of error as #87: a rule applied where it did not belong. Found by auditing for others after that one.