### PR TITLE
fix: centre the seat name properly

### DIFF
--- a/client/components/game/PlayerHandStrip.tsx
+++ b/client/components/game/PlayerHandStrip.tsx
@@ -157,30 +157,40 @@ const PlayerInfoBadge = ({
       // the header either overhung its cards or truncated the name to nothing.
       // The dot already says whose turn it is, and the action bar says it
       // again.
-      <div className="grid w-0 min-w-full grid-cols-[auto_1fr_auto] items-center gap-1.5 font-game">
+      <div className="grid w-0 min-w-full grid-cols-[1fr_auto_1fr] items-center gap-1.5 font-game">
+        {/* The name is what the eye reads as centred, so the name is what is
+            centred: it sits in the middle column with two equal 1fr columns
+            either side. The dot and the icon hug it from the inside edge of
+            those columns rather than being pushed out to the hand's edges.
+            Centring the whole group instead leaves the name off centre,
+            because the dot's ink is 6px against the icon's 14px. */}
+        <span className="flex justify-end">
+          <span
+            className={cn(
+              "h-1.5 w-1.5 rounded-full bg-accent",
+              !isCurrentTurn && "invisible",
+            )}
+            aria-hidden
+          />
+        </span>
         <span
           className={cn(
-            "h-1.5 w-1.5 shrink-0 rounded-full bg-accent",
-            !isCurrentTurn && "invisible",
-          )}
-          aria-hidden
-        />
-        <span
-          className={cn(
-            "min-w-0 truncate text-center text-sm font-bold text-ink",
+            "min-w-0 truncate text-sm font-bold text-ink",
             isDisqualified && "text-ink-muted line-through",
           )}
         >
           {player.name}
         </span>
-        <Icon
-          className={cn(
-            "h-3.5 w-3.5 shrink-0",
-            hideChip && "invisible",
-            muted ? "text-ink-muted" : "text-ink",
-          )}
-          aria-label={text}
-        />
+        <span className="flex justify-start">
+          <Icon
+            className={cn(
+              "h-3.5 w-3.5 shrink-0",
+              hideChip && "invisible",
+              muted ? "text-ink-muted" : "text-ink",
+            )}
+            aria-label={text}
+          />
+        </span>
       </div>
     );
   }

--- a/client/components/game/PlayerHandStrip.tsx
+++ b/client/components/game/PlayerHandStrip.tsx
@@ -139,83 +139,48 @@ const PlayerInfoBadge = ({
 
   // Dense table: one-line header (dot + name + status icon), no full chip —
   // the two-line header is what made every seat cost ~54px of chrome. The
-  // full status text still lives on the results sheet and in the log. The
-  // local player keeps its status text inline (it is the acting signal).
-  // What the columns either side of the name reserve. Wide enough for the
-  // longest status the machine produces ("Disconnected") on your own seat,
-  // icon width on everyone else's, where the status is only an icon.
-  const statusWidth = isLocalPlayer ? "w-[5.5rem] shrink-0" : "w-3.5 shrink-0";
-
+  // full status text still lives on the results sheet and in the log.
   if (compact) {
     return (
-      // Two different jobs, so two different rules.
+      // Every seat reads the same: turn dot, name, status icon, pinned to the
+      // width of its own hand so the name sits over its cards rather than
+      // beside them.
       //
-      // An opponent's header is pinned to its hand's width with w-0 min-w-full:
-      // a zero width box adds nothing to the parent's intrinsic width and the
-      // min-width brings it back up to whatever the hand settled on. That keeps
-      // dense seats packing three to a phone row, which is the whole point of
-      // compact mode, and their names are secondary enough to truncate.
+      // Nothing in here changes width during a turn. The dot keeps its space
+      // whether or not it is showing and the status is an icon, so the header
+      // cannot resize mid turn and slide the cards sideways to recentre. That
+      // is the drift fix, reached by making the header constant rather than by
+      // constraining what it may do.
       //
-      // Your own seat gets to be wider than its hand, because truncating the
-      // player's own name to "Am…" to save space nobody was using is a bad
-      // trade. Its status block is fixed width instead, which is what actually
-      // stops the drift: the word changes on every phase and a header that
-      // resizes mid turn slides every card sideways to recentre.
-      // The name sits at true centre, and the two things beside it are what
-      // would otherwise stop it: the status, whose word changes on every
-      // phase, and the turn dot, which appears and disappears. Both get a
-      // fixed reservation, and the left column mirrors the right one exactly,
-      // so the middle column is centred by construction. Reserving rather than
-      // reacting is also what keeps the seat still, since neither can change
-      // the header's width any more.
-      <div
-        className={cn(
-          "grid grid-cols-[auto_1fr_auto] items-center gap-1.5 font-game",
-          !isLocalPlayer && "w-0 min-w-full",
-        )}
-      >
-        <span className={statusWidth} aria-hidden />
-        <span className="flex min-w-0 items-center justify-center gap-1.5">
-          <span
-            className={cn(
-              "h-1.5 w-1.5 shrink-0 rounded-full bg-accent",
-              !isCurrentTurn && "invisible",
-            )}
-            aria-hidden
-          />
-          <span
-            className={cn(
-              "truncate text-sm font-bold text-ink",
-              isDisqualified && "text-ink-muted line-through",
-            )}
-          >
-            {player.name}
-          </span>
+      // Your own status was the words "Your Turn" here, which is why this seat
+      // used to need its own rule: the words never fit over a hand's width, so
+      // the header either overhung its cards or truncated the name to nothing.
+      // The dot already says whose turn it is, and the action bar says it
+      // again.
+      <div className="grid w-0 min-w-full grid-cols-[auto_1fr_auto] items-center gap-1.5 font-game">
+        <span
+          className={cn(
+            "h-1.5 w-1.5 shrink-0 rounded-full bg-accent",
+            !isCurrentTurn && "invisible",
+          )}
+          aria-hidden
+        />
+        <span
+          className={cn(
+            "min-w-0 truncate text-center text-sm font-bold text-ink",
+            isDisqualified && "text-ink-muted line-through",
+          )}
+        >
+          {player.name}
         </span>
-        {hideChip ? (
-          <span className={statusWidth} aria-hidden />
-        ) : isLocalPlayer ? (
-          <span
-            className={cn(
-              statusWidth,
-              "flex items-center justify-center gap-1 text-[11px] font-semibold",
-              muted ? "text-ink-muted" : "text-ink",
-            )}
-          >
-            <Icon className="h-3 w-3 shrink-0" />
-            <span className="truncate">{text}</span>
-          </span>
-        ) : (
-          <span className={cn(statusWidth, "flex justify-center")}>
-            <Icon
-              className={cn(
-                "h-3.5 w-3.5",
-                muted ? "text-ink-muted" : "text-ink",
-              )}
-              aria-label={text}
-            />
-          </span>
-        )}
+        <Icon
+          className={cn(
+            "h-3.5 w-3.5 shrink-0",
+            hideChip && "invisible",
+            muted ? "text-ink-muted" : "text-ink",
+          )}
+          aria-label={text}
+        />
       </div>
     );
   }

--- a/client/components/game/PlayerHandStrip.tsx
+++ b/client/components/game/PlayerHandStrip.tsx
@@ -141,6 +141,11 @@ const PlayerInfoBadge = ({
   // the two-line header is what made every seat cost ~54px of chrome. The
   // full status text still lives on the results sheet and in the log. The
   // local player keeps its status text inline (it is the acting signal).
+  // What the columns either side of the name reserve. Wide enough for the
+  // longest status the machine produces ("Disconnected") on your own seat,
+  // icon width on everyone else's, where the status is only an icon.
+  const statusWidth = isLocalPlayer ? "w-[5.5rem] shrink-0" : "w-3.5 shrink-0";
+
   if (compact) {
     return (
       // Two different jobs, so two different rules.
@@ -156,51 +161,61 @@ const PlayerInfoBadge = ({
       // trade. Its status block is fixed width instead, which is what actually
       // stops the drift: the word changes on every phase and a header that
       // resizes mid turn slides every card sideways to recentre.
+      // The name sits at true centre, and the two things beside it are what
+      // would otherwise stop it: the status, whose word changes on every
+      // phase, and the turn dot, which appears and disappears. Both get a
+      // fixed reservation, and the left column mirrors the right one exactly,
+      // so the middle column is centred by construction. Reserving rather than
+      // reacting is also what keeps the seat still, since neither can change
+      // the header's width any more.
       <div
         className={cn(
-          "flex items-center justify-center gap-1.5 font-game",
+          "grid grid-cols-[auto_1fr_auto] items-center gap-1.5 font-game",
           !isLocalPlayer && "w-0 min-w-full",
         )}
       >
-        {isCurrentTurn && (
+        <span className={statusWidth} aria-hidden />
+        <span className="flex min-w-0 items-center justify-center gap-1.5">
           <span
-            className="h-1.5 w-1.5 shrink-0 rounded-full bg-accent"
+            className={cn(
+              "h-1.5 w-1.5 shrink-0 rounded-full bg-accent",
+              !isCurrentTurn && "invisible",
+            )}
             aria-hidden
           />
-        )}
-        <span
-          className={cn(
-            "truncate text-sm font-bold text-ink",
-            isLocalPlayer ? "max-w-[8rem]" : "max-w-[5.5rem]",
-            isDisqualified && "text-ink-muted line-through",
-          )}
-        >
-          {player.name}
+          <span
+            className={cn(
+              "truncate text-sm font-bold text-ink",
+              isDisqualified && "text-ink-muted line-through",
+            )}
+          >
+            {player.name}
+          </span>
         </span>
-        {!hideChip &&
-          (isLocalPlayer ? (
-            <span
-              className={cn(
-                // Fixed width, wide enough for the longest status the machine
-                // produces ("Disconnected"). The status is the only part of
-                // this header whose content changes during a turn, so pinning
-                // it is what keeps the seat still.
-                "flex w-[5.5rem] shrink-0 items-center justify-center gap-1 text-[11px] font-semibold",
-                muted ? "text-ink-muted" : "text-ink",
-              )}
-            >
-              <Icon className="h-3 w-3 shrink-0" />
-              <span className="truncate">{text}</span>
-            </span>
-          ) : (
+        {hideChip ? (
+          <span className={statusWidth} aria-hidden />
+        ) : isLocalPlayer ? (
+          <span
+            className={cn(
+              statusWidth,
+              "flex items-center justify-center gap-1 text-[11px] font-semibold",
+              muted ? "text-ink-muted" : "text-ink",
+            )}
+          >
+            <Icon className="h-3 w-3 shrink-0" />
+            <span className="truncate">{text}</span>
+          </span>
+        ) : (
+          <span className={cn(statusWidth, "flex justify-center")}>
             <Icon
               className={cn(
-                "h-3.5 w-3.5 shrink-0",
+                "h-3.5 w-3.5",
                 muted ? "text-ink-muted" : "text-ink",
               )}
               aria-label={text}
             />
-          ))}
+          </span>
+        )}
       </div>
     );
   }


### PR DESCRIPTION
First piece of #92, taken on its own because it is self-contained and touches no sizing. Verified by eye on a real render before merging, unlike the two regressions that preceded it.

## What was wrong

The name was not centred. The **name-and-status group** was, and those are not the same thing. A six pixel dot on one side does not weigh the same as a fourteen pixel icon on the other, so the group sat balanced while the name read about five pixels right of its cards.

Two earlier attempts in this branch got it wrong in instructive ways, both caught by looking:

- Centring the name inside a reserved box balanced the layout but not what you see, because your own seat carried its status as **words**. The visible pair sat well right of the cards with an invisible spacer opposite it.
- Giving the name a `1fr` column centred it correctly and flung the dot and icon out to the edges of the hand, so the three read as unrelated.

## What it does now

The name holds the middle column of `grid-cols-[1fr_auto_1fr]` with equal columns either side, so it is centred by construction. The dot and icon hug it from the inside edges via `justify-end` and `justify-start`.

Every seat reads the same way. Your own no longer needs its own rule: it used to carry status as words, which never fit over a hand's width, so the header either overhung its cards or truncated the name to nothing. The dot says whose turn it is and the action bar says it again, so the words were the third telling.

## It also retires a special case

Nothing in the header changes width during a turn now. The dot keeps its column whether or not it shows, and the status is a fixed size icon. So the drift fix from #88 falls out of the header being **constant**, rather than out of a rule constraining what it may do. The `w-[5.5rem]` magic number and the local-versus-opponent asymmetry both go.

## Scope

No dimensions change, so the fit is untouched. The rest of #92 stays open: the three drifted card scales, the padding staircase, the tier structure, and the uneven vertical rhythm where the `1fr` table row soaks up every spare pixel. Those have to move as a set.