### PR TITLE
docs: correct a comment about late joiners

### DIFF
--- a/client/components/game/RoundSummary.tsx
+++ b/client/components/game/RoundSummary.tsx
@@ -120,8 +120,9 @@ export const RoundSummary = ({
   const seriesStarted = players.some((p) => (playerWins[p.id] ?? 0) > 0);
 
   // One-shot recap from the accumulated log (append-only; merged in the
-  // machine). Counted once on mount. Late joiners hold only a log tail, so
-  // counts can undercount for them.
+  // machine). Counted once on mount. A player who reconnects mid round is
+  // sent the log again, so their counts are whatever that log holds rather
+  // than what they personally witnessed.
   const actorRef = useUIActorRef();
   const recap = React.useMemo(() => {
     const log = actorRef.getSnapshot().context.currentGameState?.log ?? [];


### PR DESCRIPTION
There are none.

`PLAYER_JOIN_REQUEST` is handled only inside `WAITING_FOR_PLAYERS` in `game-machine.ts`, so once a game starts nobody new can enter it. The comment in `RoundSummary.tsx` described a case the machine does not allow.

Worth fixing rather than leaving, because it is exactly the sort of comment that gets believed and reasoned from. It was: in a design discussion about whether cumulative scores could be accumulated client side, I used it as evidence, and the owner caught it.

The real case is a player **reconnecting** to a game they were already in, which is a different thing with different consequences, and the comment now says that instead.

Comment only, no behaviour change.