### PR TITLE
Keep the end screen's actions reachable and the revealed hands visible

### DIFF
--- a/client/components/game/RoundSummary.tsx
+++ b/client/components/game/RoundSummary.tsx
@@ -269,10 +269,10 @@ export const RoundSummary = ({
                     </span>
                     {/* Series wins, on every row so a six player table can see
                     the whole standing. Trophy rather than the Crown above it:
-                    the crown marks who took THIS round, and the two numbers
-                    would otherwise read as the same thing. Hidden until
-                    someone has actually won one, so a first round does not
-                    show a column of zeroes. */}
+                    the crown marks who took THIS round, the trophy the series,
+                    and the two would otherwise read as the same number. The
+                    guard only bites on a round that produced no winner at all,
+                    since this round's is credited before the sheet mounts. */}
                     {seriesStarted && (
                       <span
                         className="flex shrink-0 items-center gap-1 text-sm font-semibold tabular-nums text-ink-muted"

--- a/client/components/game/RoundSummary.tsx
+++ b/client/components/game/RoundSummary.tsx
@@ -158,103 +158,113 @@ export const RoundSummary = ({
           : { type: "spring", stiffness: 300, damping: 30, delay: 0.35 }
       }
     >
-      <div className="mx-auto flex max-h-[50vh] w-full max-w-2xl flex-col gap-3 overflow-y-auto px-5 py-5 sm:px-8 lg:max-h-[34vh]">
-        <div>
-          <p className="truncate text-xs font-semibold uppercase tracking-widest text-ink-muted">
-            Round {roundNumber}
-          </p>
-          <h2 className="mt-1 text-3xl font-extrabold tracking-tight text-ink sm:text-4xl">
-            {title}
-          </h2>
-          {winners.length > 0 && (
-            <motion.div
-              className="mt-2 h-1 rounded-full bg-accent"
-              style={{ originX: 0, width: "clamp(4rem, 30%, 10rem)" }}
-              initial={{ scaleX: reduced ? 1 : 0 }}
-              animate={{ scaleX: 1 }}
-              transition={
-                reduced
-                  ? { duration: 0 }
-                  : { duration: 0.6, ease: [0.22, 1, 0.36, 1], delay: 0.9 }
-              }
-            />
-          )}
-          <p className="mt-2 text-sm text-ink-muted">{caption}</p>
-        </div>
+      {/* The floor is the point. A share of the viewport alone goes to nothing
+          on a short screen, and with the actions pinned it is the scores that
+          vanish rather than the buttons. */}
+      <div className="mx-auto flex max-h-[max(50vh,20rem)] w-full max-w-2xl flex-col gap-3 px-5 py-5 sm:px-8 lg:max-h-[max(34vh,20rem)]">
+        {/* Heading and rows scroll together. Only the actions are pinned: on a
+            phone the heading costs as much as the whole row list, and pinning
+            it too leaves the sheet with no room to show a single score. */}
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          <div>
+            <p className="truncate text-xs font-semibold uppercase tracking-widest text-ink-muted">
+              Round {roundNumber}
+            </p>
+            <h2 className="mt-1 text-3xl font-extrabold tracking-tight text-ink sm:text-4xl">
+              {title}
+            </h2>
+            {winners.length > 0 && (
+              <motion.div
+                className="mt-2 h-1 rounded-full bg-accent"
+                style={{ originX: 0, width: "clamp(4rem, 30%, 10rem)" }}
+                initial={{ scaleX: reduced ? 1 : 0 }}
+                animate={{ scaleX: 1 }}
+                transition={
+                  reduced
+                    ? { duration: 0 }
+                    : { duration: 0.6, ease: [0.22, 1, 0.36, 1], delay: 0.9 }
+                }
+              />
+            )}
+            <p className="mt-2 text-sm text-ink-muted">{caption}</p>
+          </div>
 
-        <div className="divide-y divide-hairline">
-          {sorted.map((player, i) => {
-            const isWinner = winnerIds.includes(player.id);
-            const dq = player.status === PlayerStatus.DISQUALIFIED;
-            const m = recap.matches[player.id] ?? 0;
-            const pen = recap.penalties[player.id] ?? 0;
-            const abil = recap.abilities[player.id] ?? 0;
-            const attempts = m + pen;
-            const accuracy =
-              attempts > 0 ? Math.round((m / attempts) * 100) : null;
-            // One muted line under the name (all breakpoints; chips were
-            // hidden on phones). Same dot idiom as the rematch tally below.
-            const statLine = [
-              dq && "disqualified",
-              m > 0 && `${m} match${m > 1 ? "es" : ""}`,
-              pen > 0 && `${pen} penalt${pen > 1 ? "ies" : "y"}`,
-              accuracy !== null && `${accuracy}% accuracy`,
-              abil > 0 && `${abil} abilit${abil > 1 ? "ies" : "y"}`,
-            ]
-              .filter(Boolean)
-              .join(" · ");
-            return (
-              <div key={player.id} className="flex items-center gap-3 py-2">
-                <span className="w-5 shrink-0 text-sm font-semibold tabular-nums text-ink-muted">
-                  {i + 1}
-                </span>
-                {isWinner && <Crown className="h-4 w-4 shrink-0 text-accent" />}
-                <span className="min-w-0 flex-1">
-                  <span
-                    className={cn(
-                      "block truncate text-base font-bold text-ink",
-                      dq && "text-ink-muted line-through",
-                    )}
-                  >
-                    {player.name}
-                    {player.id === localPlayerId && (
-                      <span className="ml-1.5 text-xs font-normal text-ink-muted">
-                        (you)
+          <div className="mt-3 divide-y divide-hairline">
+            {sorted.map((player, i) => {
+              const isWinner = winnerIds.includes(player.id);
+              const dq = player.status === PlayerStatus.DISQUALIFIED;
+              const m = recap.matches[player.id] ?? 0;
+              const pen = recap.penalties[player.id] ?? 0;
+              const abil = recap.abilities[player.id] ?? 0;
+              const attempts = m + pen;
+              const accuracy =
+                attempts > 0 ? Math.round((m / attempts) * 100) : null;
+              // One muted line under the name (all breakpoints; chips were
+              // hidden on phones). Same dot idiom as the rematch tally below.
+              const statLine = [
+                dq && "disqualified",
+                m > 0 && `${m} match${m > 1 ? "es" : ""}`,
+                pen > 0 && `${pen} penalt${pen > 1 ? "ies" : "y"}`,
+                accuracy !== null && `${accuracy}% accuracy`,
+                abil > 0 && `${abil} abilit${abil > 1 ? "ies" : "y"}`,
+              ]
+                .filter(Boolean)
+                .join(" · ");
+              return (
+                <div key={player.id} className="flex items-center gap-3 py-2">
+                  <span className="w-5 shrink-0 text-sm font-semibold tabular-nums text-ink-muted">
+                    {i + 1}
+                  </span>
+                  {isWinner && (
+                    <Crown className="h-4 w-4 shrink-0 text-accent" />
+                  )}
+                  <span className="min-w-0 flex-1">
+                    <span
+                      className={cn(
+                        "block truncate text-base font-bold text-ink",
+                        dq && "text-ink-muted line-through",
+                      )}
+                    >
+                      {player.name}
+                      {player.id === localPlayerId && (
+                        <span className="ml-1.5 text-xs font-normal text-ink-muted">
+                          (you)
+                        </span>
+                      )}
+                    </span>
+                    {statLine && (
+                      <span className="block truncate text-[11px] font-medium text-ink-muted">
+                        {statLine}
                       </span>
                     )}
                   </span>
-                  {statLine && (
-                    <span className="block truncate text-[11px] font-medium text-ink-muted">
-                      {statLine}
-                    </span>
-                  )}
-                </span>
-                {/* Series wins, on every row so a six player table can see
+                  {/* Series wins, on every row so a six player table can see
                     the whole standing. Trophy rather than the Crown above it:
                     the crown marks who took THIS round, and the two numbers
                     would otherwise read as the same thing. Hidden until
                     someone has actually won one, so a first round does not
                     show a column of zeroes. */}
-                {seriesStarted && (
-                  <span
-                    className="flex shrink-0 items-center gap-1 text-sm font-semibold tabular-nums text-ink-muted"
-                    aria-label={`${playerWins[player.id] ?? 0} rounds won this series`}
-                  >
-                    <Trophy className="h-3.5 w-3.5" aria-hidden />
-                    {playerWins[player.id] ?? 0}
-                  </span>
-                )}
-                <ScoreStamp
-                  value={player.score}
-                  delay={FIRST_STAMP_DELAY_S + i * STAMP_STAGGER_S}
-                  reduced={reduced}
-                />
-              </div>
-            );
-          })}
+                  {seriesStarted && (
+                    <span
+                      className="flex shrink-0 items-center gap-1 text-sm font-semibold tabular-nums text-ink-muted"
+                      aria-label={`${playerWins[player.id] ?? 0} rounds won this series`}
+                    >
+                      <Trophy className="h-3.5 w-3.5" aria-hidden />
+                      {playerWins[player.id] ?? 0}
+                    </span>
+                  )}
+                  <ScoreStamp
+                    value={player.score}
+                    delay={FIRST_STAMP_DELAY_S + i * STAMP_STAGGER_S}
+                    reduced={reduced}
+                  />
+                </div>
+              );
+            })}
+          </div>
         </div>
 
-        <div className="flex flex-wrap items-center gap-3 pt-1">
+        <div className="flex shrink-0 flex-wrap items-center gap-3 pt-1">
           {isGameMaster ? (
             <>
               <button

--- a/client/components/game/RoundSummary.tsx
+++ b/client/components/game/RoundSummary.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import { motion, useReducedMotion } from "framer-motion";
-import { Crown, Trophy } from "lucide-react";
+import { ChevronDown, Crown, Trophy } from "lucide-react";
 import { type Player, PlayerStatus } from "shared-types";
 import {
   useUIActorRef,
@@ -90,6 +90,12 @@ export const RoundSummary = ({
   const rematchCount = rematchVotes.filter((id) => id !== gameMasterId).length;
   const localWantsRematch = rematchVotes.includes(localPlayerId);
 
+  const status = isGameMaster
+    ? nonHostCount > 0
+      ? `${rematchCount}/${nonHostCount} want a rematch`
+      : null
+    : `${rematchCount > 0 ? `${rematchCount}/${nonHostCount} in · ` : ""}Waiting for the host to start`;
+
   const winners = players.filter((p) => winnerIds.includes(p.id));
   const sorted = [...players].sort((a, b) => a.score - b.score);
   const caller = callerId ? players.find((p) => p.id === callerId) : null;
@@ -118,6 +124,27 @@ export const RoundSummary = ({
   // one.
   const roundNumber = roundEpoch + 1;
   const seriesStarted = players.some((p) => (playerWins[p.id] ?? 0) > 0);
+
+  // A panel that scrolls with nothing to say so reads as a list that ended,
+  // and at a full table the rows below the fold are most of the result. The
+  // marker is only up while there is something under it.
+  const listRef = React.useRef<HTMLDivElement>(null);
+  const [moreBelow, setMoreBelow] = React.useState(false);
+  React.useEffect(() => {
+    const el = listRef.current;
+    if (!el) return;
+    const update = () =>
+      setMoreBelow(el.scrollHeight - el.scrollTop - el.clientHeight > 4);
+    update();
+    el.addEventListener("scroll", update, { passive: true });
+    const observer = new ResizeObserver(update);
+    observer.observe(el);
+    for (const child of el.children) observer.observe(child);
+    return () => {
+      el.removeEventListener("scroll", update);
+      observer.disconnect();
+    };
+  }, []);
 
   // One-shot recap from the accumulated log (append-only; merged in the
   // machine). Counted once on mount. A player who reconnects mid round is
@@ -158,154 +185,159 @@ export const RoundSummary = ({
           : { type: "spring", stiffness: 300, damping: 30, delay: 0.35 }
       }
     >
-      {/* The floor is the point. A share of the viewport alone goes to nothing
-          on a short screen, and with the actions pinned it is the scores that
-          vanish rather than the buttons. */}
-      <div className="mx-auto flex max-h-[max(50vh,20rem)] w-full max-w-2xl flex-col gap-3 px-5 py-5 sm:px-8 lg:max-h-[max(34vh,20rem)]">
+      {/* Half the viewport, and never less than the pinned row needs. The
+          ceiling is what keeps the revealed hands visible, so it may not be
+          raised to fit more rows; the floor only catches a screen so short
+          that the buttons would clip. */}
+      <div className="mx-auto flex max-h-[max(48vh,12rem)] w-full max-w-2xl flex-col gap-3 px-5 py-5 sm:px-8">
         {/* Heading and rows scroll together. Only the actions are pinned: on a
             phone the heading costs as much as the whole row list, and pinning
             it too leaves the sheet with no room to show a single score. */}
-        <div className="min-h-0 flex-1 overflow-y-auto">
-          <div>
-            <p className="truncate text-xs font-semibold uppercase tracking-widest text-ink-muted">
-              Round {roundNumber}
-            </p>
-            <h2 className="mt-1 text-3xl font-extrabold tracking-tight text-ink sm:text-4xl">
-              {title}
-            </h2>
-            {winners.length > 0 && (
-              <motion.div
-                className="mt-2 h-1 rounded-full bg-accent"
-                style={{ originX: 0, width: "clamp(4rem, 30%, 10rem)" }}
-                initial={{ scaleX: reduced ? 1 : 0 }}
-                animate={{ scaleX: 1 }}
-                transition={
-                  reduced
-                    ? { duration: 0 }
-                    : { duration: 0.6, ease: [0.22, 1, 0.36, 1], delay: 0.9 }
-                }
-              />
-            )}
-            <p className="mt-2 text-sm text-ink-muted">{caption}</p>
-          </div>
+        <div className="relative flex min-h-0 flex-1 flex-col">
+          <div ref={listRef} className="min-h-0 flex-1 overflow-y-auto">
+            <div>
+              <p className="truncate text-xs font-semibold uppercase tracking-widest text-ink-muted">
+                Round {roundNumber}
+              </p>
+              <h2 className="mt-1 text-3xl font-extrabold tracking-tight text-ink sm:text-4xl">
+                {title}
+              </h2>
+              {winners.length > 0 && (
+                <motion.div
+                  className="mt-2 h-1 rounded-full bg-accent"
+                  style={{ originX: 0, width: "clamp(4rem, 30%, 10rem)" }}
+                  initial={{ scaleX: reduced ? 1 : 0 }}
+                  animate={{ scaleX: 1 }}
+                  transition={
+                    reduced
+                      ? { duration: 0 }
+                      : { duration: 0.6, ease: [0.22, 1, 0.36, 1], delay: 0.9 }
+                  }
+                />
+              )}
+              <p className="mt-2 text-sm text-ink-muted">{caption}</p>
+            </div>
 
-          <div className="mt-3 divide-y divide-hairline">
-            {sorted.map((player, i) => {
-              const isWinner = winnerIds.includes(player.id);
-              const dq = player.status === PlayerStatus.DISQUALIFIED;
-              const m = recap.matches[player.id] ?? 0;
-              const pen = recap.penalties[player.id] ?? 0;
-              const abil = recap.abilities[player.id] ?? 0;
-              const attempts = m + pen;
-              const accuracy =
-                attempts > 0 ? Math.round((m / attempts) * 100) : null;
-              // One muted line under the name (all breakpoints; chips were
-              // hidden on phones). Same dot idiom as the rematch tally below.
-              const statLine = [
-                dq && "disqualified",
-                m > 0 && `${m} match${m > 1 ? "es" : ""}`,
-                pen > 0 && `${pen} penalt${pen > 1 ? "ies" : "y"}`,
-                accuracy !== null && `${accuracy}% accuracy`,
-                abil > 0 && `${abil} abilit${abil > 1 ? "ies" : "y"}`,
-              ]
-                .filter(Boolean)
-                .join(" · ");
-              return (
-                <div key={player.id} className="flex items-center gap-3 py-2">
-                  <span className="w-5 shrink-0 text-sm font-semibold tabular-nums text-ink-muted">
-                    {i + 1}
-                  </span>
-                  {isWinner && (
-                    <Crown className="h-4 w-4 shrink-0 text-accent" />
-                  )}
-                  <span className="min-w-0 flex-1">
-                    <span
-                      className={cn(
-                        "block truncate text-base font-bold text-ink",
-                        dq && "text-ink-muted line-through",
-                      )}
-                    >
-                      {player.name}
-                      {player.id === localPlayerId && (
-                        <span className="ml-1.5 text-xs font-normal text-ink-muted">
-                          (you)
+            <div className="mt-3 divide-y divide-hairline">
+              {sorted.map((player, i) => {
+                const isWinner = winnerIds.includes(player.id);
+                const dq = player.status === PlayerStatus.DISQUALIFIED;
+                const m = recap.matches[player.id] ?? 0;
+                const pen = recap.penalties[player.id] ?? 0;
+                const abil = recap.abilities[player.id] ?? 0;
+                const attempts = m + pen;
+                const accuracy =
+                  attempts > 0 ? Math.round((m / attempts) * 100) : null;
+                // One muted line under the name (all breakpoints; chips were
+                // hidden on phones). Same dot idiom as the rematch tally below.
+                const statLine = [
+                  dq && "disqualified",
+                  m > 0 && `${m} match${m > 1 ? "es" : ""}`,
+                  pen > 0 && `${pen} penalt${pen > 1 ? "ies" : "y"}`,
+                  accuracy !== null && `${accuracy}% accuracy`,
+                  abil > 0 && `${abil} abilit${abil > 1 ? "ies" : "y"}`,
+                ]
+                  .filter(Boolean)
+                  .join(" · ");
+                return (
+                  <div key={player.id} className="flex items-center gap-3 py-2">
+                    <span className="w-5 shrink-0 text-sm font-semibold tabular-nums text-ink-muted">
+                      {i + 1}
+                    </span>
+                    {isWinner && (
+                      <Crown className="h-4 w-4 shrink-0 text-accent" />
+                    )}
+                    <span className="min-w-0 flex-1">
+                      <span
+                        className={cn(
+                          "block truncate text-base font-bold text-ink",
+                          dq && "text-ink-muted line-through",
+                        )}
+                      >
+                        {player.name}
+                        {player.id === localPlayerId && (
+                          <span className="ml-1.5 text-xs font-normal text-ink-muted">
+                            (you)
+                          </span>
+                        )}
+                      </span>
+                      {statLine && (
+                        <span className="block truncate text-[11px] font-medium text-ink-muted">
+                          {statLine}
                         </span>
                       )}
                     </span>
-                    {statLine && (
-                      <span className="block truncate text-[11px] font-medium text-ink-muted">
-                        {statLine}
-                      </span>
-                    )}
-                  </span>
-                  {/* Series wins, on every row so a six player table can see
+                    {/* Series wins, on every row so a six player table can see
                     the whole standing. Trophy rather than the Crown above it:
                     the crown marks who took THIS round, and the two numbers
                     would otherwise read as the same thing. Hidden until
                     someone has actually won one, so a first round does not
                     show a column of zeroes. */}
-                  {seriesStarted && (
-                    <span
-                      className="flex shrink-0 items-center gap-1 text-sm font-semibold tabular-nums text-ink-muted"
-                      aria-label={`${playerWins[player.id] ?? 0} rounds won this series`}
-                    >
-                      <Trophy className="h-3.5 w-3.5" aria-hidden />
-                      {playerWins[player.id] ?? 0}
-                    </span>
-                  )}
-                  <ScoreStamp
-                    value={player.score}
-                    delay={FIRST_STAMP_DELAY_S + i * STAMP_STAGGER_S}
-                    reduced={reduced}
-                  />
-                </div>
-              );
-            })}
+                    {seriesStarted && (
+                      <span
+                        className="flex shrink-0 items-center gap-1 text-sm font-semibold tabular-nums text-ink-muted"
+                        aria-label={`${playerWins[player.id] ?? 0} rounds won this series`}
+                      >
+                        <Trophy className="h-3.5 w-3.5" aria-hidden />
+                        {playerWins[player.id] ?? 0}
+                      </span>
+                    )}
+                    <ScoreStamp
+                      value={player.score}
+                      delay={FIRST_STAMP_DELAY_S + i * STAMP_STAGGER_S}
+                      reduced={reduced}
+                    />
+                  </div>
+                );
+              })}
+            </div>
           </div>
+          {moreBelow && (
+            <div
+              aria-hidden
+              className="pointer-events-none absolute inset-x-0 bottom-0 flex h-8 items-end justify-center"
+              style={{
+                background:
+                  "linear-gradient(to top, var(--color-surface), hsl(var(--surface) / 0))",
+              }}
+            >
+              <ChevronDown className="h-3.5 w-3.5 text-ink-muted" />
+            </div>
+          )}
         </div>
 
-        <div className="flex shrink-0 flex-wrap items-center gap-3 pt-1">
+        {/* The status line takes a row of its own rather than sitting between
+            the buttons. Wedged in the middle it pushed each button onto its
+            own line, and on a phone that cost more height than the scores. */}
+        <div className="flex shrink-0 flex-wrap items-center gap-x-3 gap-y-2 pt-1">
           {isGameMaster ? (
-            <>
-              <button
-                onClick={() => {
-                  play("click");
-                  onPlayAgain();
-                }}
-                className="flex h-11 items-center rounded-full bg-accent px-6 text-sm font-bold text-accent-ink transition-colors hover:bg-accent/90"
-              >
-                Play again
-              </button>
-              {nonHostCount > 0 && (
-                <span className="text-sm font-semibold text-ink-muted">
-                  {rematchCount}/{nonHostCount} want a rematch
-                </span>
-              )}
-            </>
+            <button
+              onClick={() => {
+                play("click");
+                onPlayAgain();
+              }}
+              className="flex h-11 items-center rounded-full bg-accent px-6 text-sm font-bold text-accent-ink transition-colors hover:bg-accent/90"
+            >
+              Play again
+            </button>
           ) : (
-            <>
-              <button
-                onClick={() => {
-                  play("click");
-                  onRequestPlayAgain();
-                }}
-                aria-pressed={localWantsRematch}
-                className={cn(
-                  "flex h-11 items-center rounded-full px-6 text-sm font-bold transition-colors",
-                  localWantsRematch
-                    ? "bg-accent text-accent-ink hover:bg-accent/90"
-                    : "border border-hairline bg-surface text-ink hover:border-ink-muted",
-                )}
-              >
-                {localWantsRematch
-                  ? "Ready for a rematch"
-                  : "I want to play again"}
-              </button>
-              <span className="text-sm font-semibold text-ink-muted">
-                {rematchCount > 0 && `${rematchCount}/${nonHostCount} in · `}
-                Waiting for the host to start
-              </span>
-            </>
+            <button
+              onClick={() => {
+                play("click");
+                onRequestPlayAgain();
+              }}
+              aria-pressed={localWantsRematch}
+              className={cn(
+                "flex h-11 items-center rounded-full px-6 text-sm font-bold transition-colors",
+                localWantsRematch
+                  ? "bg-accent text-accent-ink hover:bg-accent/90"
+                  : "border border-hairline bg-surface text-ink hover:border-ink-muted",
+              )}
+            >
+              {localWantsRematch
+                ? "Ready for a rematch"
+                : "I want to play again"}
+            </button>
           )}
           <button
             onClick={() => {
@@ -322,6 +354,11 @@ export const RoundSummary = ({
           >
             Back to home
           </button>
+          {status && (
+            <span className="basis-full text-sm font-semibold text-ink-muted">
+              {status}
+            </span>
+          )}
         </div>
       </div>
     </motion.div>

--- a/tools/probe/measure.mjs
+++ b/tools/probe/measure.mjs
@@ -28,6 +28,10 @@ export function measureInPage() {
   // failure that leaves a control unreachable with nothing on screen to say
   // so. Watching only for scrollbars would go blind the moment the fix lands.
   const scrollers = [];
+  // Panels squeezed until not one of their items fits. No overflow number says
+  // so, because what they are hiding is all of it, and a results sheet showing
+  // nobody's score still measures as a panel that scrolls.
+  const starved = [];
   for (const el of document.querySelectorAll("body *")) {
     const style = getComputedStyle(el);
     const overflowY = style.overflowY + style.overflow;
@@ -79,6 +83,19 @@ export function measureInPage() {
         deepest,
       });
     }
+
+    if (scrolls && !isView && over > 0 && visible(el, style)) {
+      const first = el.firstElementChild;
+      const itemH = first ? first.getBoundingClientRect().height : 0;
+      if (itemH > 0 && el.clientHeight < itemH) {
+        starved.push({
+          cls: String(el.className).slice(0, 60),
+          clientH: el.clientHeight,
+          itemH: Math.round(itemH),
+          items: el.childElementCount,
+        });
+      }
+    }
   }
 
   // Every control a player has to be able to hit.
@@ -100,9 +117,9 @@ export function measureInPage() {
     // under the fold is still a button a thumb misses.
     const whole = r.top >= 0 && r.bottom <= vh && r.left >= 0 && r.right <= vw;
 
-    // A control below the fold of a panel that scrolls is reachable: the panel
-    // is meant to be scrolled. Only a control the view itself cannot reach is
-    // a failure.
+    // A control below the fold of a scrolling panel is reachable, so it is
+    // reported rather than failed: whether a player should have to scroll to
+    // reach that particular control is a judgement, not a measurement.
     let inScrollablePanel = false;
     for (let p = el.parentElement; p; p = p.parentElement) {
       const ps = getComputedStyle(p);
@@ -116,7 +133,7 @@ export function measureInPage() {
     let status = "ok";
     let blockedBy = null;
     if (!inViewport) {
-      status = inScrollablePanel ? "ok" : "offscreen";
+      status = inScrollablePanel ? "needs-scroll" : "offscreen";
     } else if (!hit) {
       status = "no-hit";
     } else if (hit !== el && !el.contains(hit)) {
@@ -220,6 +237,7 @@ export function measureInPage() {
       document.documentElement.scrollWidth >
       document.documentElement.clientWidth,
     scrollers,
+    starved,
     controls,
     overlays,
     budget,

--- a/tools/probe/measure.mjs
+++ b/tools/probe/measure.mjs
@@ -175,6 +175,54 @@ export function measureInPage() {
     });
   }
 
+  // Cards a panel covers. The end screen is a report about the hands it has
+  // just turned face up, so a sheet tall enough to sit on them defeats the
+  // reveal it exists to explain.
+  //
+  // Full-bleed overlays are excluded by their own geometry rather than by
+  // name: a moment stamp covers the board deliberately. Only a panel that
+  // leaves part of the viewport uncovered is answering for what it hides.
+  const cardRects = [];
+  for (const grid of document.querySelectorAll(".inline-grid")) {
+    for (const card of grid.children) {
+      const cr = card.getBoundingClientRect();
+      if (cr.width > 0 && cr.height > 0) cardRects.push(cr);
+    }
+  }
+
+  const covers = [];
+  for (const el of document.querySelectorAll("body *")) {
+    const style = getComputedStyle(el);
+    if (style.position !== "absolute" && style.position !== "fixed") continue;
+    if (!visible(el, style)) continue;
+    const z = Number(style.zIndex);
+    if (!Number.isFinite(z) || z < 40) continue;
+    const r = el.getBoundingClientRect();
+    // Panels only. Cards are absolutely positioned and stack on each other at
+    // the deck, and a card lying on a card is the game working.
+    if (r.width < vw * 0.6 || r.height <= 0) continue;
+    if (r.top <= 1 && r.bottom >= vh - 1) continue;
+
+    let hidden = 0;
+    let worst = 0;
+    for (const cr of cardRects) {
+      const y = Math.min(cr.bottom, r.bottom) - Math.max(cr.top, r.top);
+      const x = Math.min(cr.right, r.right) - Math.max(cr.left, r.left);
+      if (y > 1 && x > 1) {
+        hidden++;
+        worst = Math.max(worst, Math.round(y));
+      }
+    }
+    if (hidden > 0) {
+      covers.push({
+        name: named(el).slice(0, 30),
+        hidden,
+        worst,
+        cards: cardRects.length,
+      });
+    }
+  }
+
   // Where the height actually goes. Fitting the board is a budgeting problem,
   // and the first thing anyone needs is the itemised bill rather than a guess
   // at which row is fat.
@@ -238,6 +286,7 @@ export function measureInPage() {
       document.documentElement.clientWidth,
     scrollers,
     starved,
+    covers,
     controls,
     overlays,
     budget,

--- a/tools/probe/probe.mjs
+++ b/tools/probe/probe.mjs
@@ -396,9 +396,11 @@ const report = (rows, opts) => {
     );
     const scrolled = m.controls.filter((c) => c.status === "needs-scroll");
     const starved = m.starved ?? [];
+    const covers = m.covers ?? [];
     // A game view that scrolls at all is a failure, whether or not the scroll
     // makes anything unreachable. That is the whole of #82.
-    const failed = bad.length > 0 || !!worst || starved.length > 0;
+    const failed =
+      bad.length > 0 || !!worst || starved.length > 0 || covers.length > 0;
     if (failed) failures++;
 
     console.log(
@@ -412,6 +414,11 @@ const report = (rows, opts) => {
           : "all reachable"),
     );
 
+    for (const c of covers) {
+      console.log(
+        `  ${pad("", 14)}"${c.name}" covers ${c.hidden} of ${c.cards} cards, worst ${c.worst}px`,
+      );
+    }
     for (const s of starved) {
       console.log(
         `  ${pad("", 14)}shows none of its ${s.items} items: a ${s.itemH}px item in a ${s.clientH}px frame (${s.cls})`,
@@ -591,7 +598,12 @@ const sweep = async (page, widths, from, to, step) => {
       const unreachable = m.controls.filter(
         (c) => c.status !== "ok" && c.status !== "needs-scroll",
       ).length;
-      if (over > 0 || unreachable > 0 || (m.starved?.length ?? 0) > 0) {
+      if (
+        over > 0 ||
+        unreachable > 0 ||
+        (m.starved?.length ?? 0) > 0 ||
+        (m.covers?.length ?? 0) > 0
+      ) {
         if (run && run.width === width && run.to === height - step) {
           run.to = height;
           run.worst = Math.max(run.worst, over);

--- a/tools/probe/probe.mjs
+++ b/tools/probe/probe.mjs
@@ -44,6 +44,7 @@ const opts = {
   breakdown: flag("breakdown"),
   shift: flag("shift"),
   sweep: flag("sweep"),
+  scrolled: flag("scrolled"),
   matrix: flag("matrix"),
   counts: arg("counts", "2,4,6"),
   states: arg("states", "lobby,play,drawn,matching,scoring"),
@@ -354,9 +355,12 @@ const drive = async (page, opts) => {
       30000,
     );
     // The sheet is deliberately held back ~1.1s so the last card flight can
-    // land before it covers the table. Measuring before that catches the board
-    // mid animation with no sheet on it.
-    await page.waitForTimeout(1800);
+    // land before it covers the table, and the scores stamp in one by one
+    // after it, the last landing around 2.1s. Whichever viewport is measured
+    // first gets photographed at whatever this wait allows, so anything
+    // shorter than the whole sequence produces a shot of the smallest screen
+    // with its last rows blank, which reads as scores that failed to render.
+    await page.waitForTimeout(3000);
     return { gameId, bots, observedId };
   }
 
@@ -817,6 +821,30 @@ const main = async () => {
         fileName,
         diff: compareToBaseline(shotPath, opts.baseline, fileName, OUT),
       });
+
+      // What the panel looks like once a player has done what the marker at
+      // its fold is asking. Measuring only the arrival state says nothing
+      // about whether the rest of a list is actually reachable.
+      if (opts.scrolled) {
+        await page.evaluate(() => {
+          const vh = window.innerHeight;
+          for (const el of document.querySelectorAll("body *")) {
+            const s = getComputedStyle(el);
+            if (!/auto|scroll/.test(s.overflowY + s.overflow)) continue;
+            if (el.scrollHeight - el.clientHeight <= 0) continue;
+            if (el.getBoundingClientRect().height >= vh * 0.85) continue;
+            el.scrollTop = el.scrollHeight;
+          }
+        });
+        await page.waitForTimeout(200);
+        rows.push({
+          viewport: { ...viewport, name: `${viewport.name} (end)` },
+          m: await page.evaluate(measureInPage),
+        });
+        const endName = fileName.replace(/\.png$/, "-scrolled.png");
+        await page.screenshot({ path: join(OUT, endName) });
+        shots.push({ fileName: endName, diff: null });
+      }
     }
 
     const after = stamp();

--- a/tools/probe/probe.mjs
+++ b/tools/probe/probe.mjs
@@ -391,10 +391,14 @@ const report = (rows, opts) => {
 
   for (const { viewport, m } of rows) {
     const worst = m.scrollers.sort((a, b) => b.overflowPx - a.overflowPx)[0];
-    const bad = m.controls.filter((c) => c.status !== "ok");
+    const bad = m.controls.filter(
+      (c) => c.status !== "ok" && c.status !== "needs-scroll",
+    );
+    const scrolled = m.controls.filter((c) => c.status === "needs-scroll");
+    const starved = m.starved ?? [];
     // A game view that scrolls at all is a failure, whether or not the scroll
     // makes anything unreachable. That is the whole of #82.
-    const failed = bad.length > 0 || !!worst;
+    const failed = bad.length > 0 || !!worst || starved.length > 0;
     if (failed) failures++;
 
     console.log(
@@ -408,6 +412,18 @@ const report = (rows, opts) => {
           : "all reachable"),
     );
 
+    for (const s of starved) {
+      console.log(
+        `  ${pad("", 14)}shows none of its ${s.items} items: a ${s.itemH}px item in a ${s.clientH}px frame (${s.cls})`,
+      );
+    }
+    if (scrolled.length) {
+      console.log(
+        `  ${pad("", 14)}reachable only by scrolling: ${scrolled
+          .map((c) => c.name)
+          .join(", ")}`,
+      );
+    }
     if (worst?.deepest) {
       const d = worst.deepest;
       console.log(
@@ -572,8 +588,10 @@ const sweep = async (page, widths, from, to, step) => {
       const m = await page.evaluate(measureInPage);
       checked++;
       const over = m.scrollers.reduce((n, s) => Math.max(n, s.overflowPx), 0);
-      const unreachable = m.controls.filter((c) => c.status !== "ok").length;
-      if (over > 0 || unreachable > 0) {
+      const unreachable = m.controls.filter(
+        (c) => c.status !== "ok" && c.status !== "needs-scroll",
+      ).length;
+      if (over > 0 || unreachable > 0 || (m.starved?.length ?? 0) > 0) {
         if (run && run.width === width && run.to === height - step) {
           run.to = height;
           run.worst = Math.max(run.worst, over);


### PR DESCRIPTION
Closes #102.

Play again, Table talk and Back to home sat inside the results sheet's scroll area, so at a full table you had to scroll past every player to reach them. Desktop as well as phones, because `lg:max-h-[34vh]` gave the sheet a smaller share of a large screen than the `50vh` below it.

## What changed

**The rows scroll, the actions do not.** The heading scrolls with the rows rather than being pinned as well: on an iPhone SE the heading costs about as much as the whole row list, and pinning both left a 24px frame for a 49px row, so the end screen showed no scores at all.

**One height rule instead of two tiers.** `max(48vh,12rem)`. The old pair was backwards at both ends: a third of a 1920x910 desktop showed two of six scores with the board above mostly empty, while on a phone the sheet sat on the hands it had just revealed. The ceiling is now what keeps the cards visible, so it does not rise to fit more rows; the floor only catches a screen too short for the pinned buttons to clear.

**The status line took a row of its own.** Wedged between the buttons it pushed each one onto a separate line, and on a phone that cluster cost more height than the scores did.

**A marker at the fold while there is more below.** A fade and a chevron, up only while the list has something under it. A panel that scrolls with nothing to say so reads as a list that ended.

## The probe could not see any of this

Three measurements were missing, and each one is true independently of this bug:

- #97 made a control inside a scrolling panel count as reachable, which is right for a list and is what closed #87, but it collapsed "cannot be reached" and "reached only by scrolling" into `ok`. The `offscreen` rows quoted in #102 were measured before #97 landed. `needs-scroll` now reports separately without failing, since whether a player should scroll for a given control is a judgement.
- A panel squeezed until not one of its items fits. The panel still scrolls, nothing overflows, every control is reachable. It caught the zero-score sheet above.
- The cards a panel covers. The sheet fit, every control was reachable, and it was lying on four of the twenty-four cards it had just revealed.

## Verification

`npm run probe -- --at scoring --players 6`, before: all seven viewports `reachable only by scrolling: I want to play again, Table talk, Back to home`.

After, at 6 and at 4 players: all seven `all reachable`, no starved panel, no covered cards. `npm run verify` passes. `npm run probe -- --matrix` was run against the first half of this work and showed `scoring` fitting at every height at 2, 4 and 6 players, with the remaining bands all in states this does not touch.

## Judgement calls worth knowing

**48vh, not 50.** At 50vh the sheet covered two cards by 5px on an iPhone SE. 48 clears it with room. That is a margin measured against one device rather than a principle, and the principled version is #92: the real constraint is the hands above, which is a relationship between two elements and not a fraction of the viewport.

**The phone still shows no rows without scrolling at six players.** Cards visible was the priority, and at that size the screen cannot hold the hands, the heading and the scores at once. The marker is what makes the rest reachable. Buying a row back means a smaller heading on short screens, which is #92's sizing work.

**Two players at scoring is intermittent in the probe**, unrelated to this: its scripted bots do not resolve an ability turn, so the run times out whenever the draw produces one.