### PR TITLE
Series standing: running totals, the end-screen block and a panel tab

### DIFF
--- a/client/components/game/GameBoard.tsx
+++ b/client/components/game/GameBoard.tsx
@@ -389,6 +389,7 @@ export function GameBoard() {
             winnerIds={winnerIds}
             localPlayerId={localPlayerId}
             playerWins={gameState.playerWins ?? {}}
+            playerTotals={gameState.playerTotals ?? {}}
             rematchVotes={gameState.rematchVotes ?? []}
             onPlayAgain={handlePlayAgain}
             onRequestPlayAgain={handleRequestPlayAgain}

--- a/client/components/game/RoundSummary.tsx
+++ b/client/components/game/RoundSummary.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import { motion, useReducedMotion } from "framer-motion";
-import { ChevronDown, Crown, Trophy } from "lucide-react";
+import { ChevronDown, Crown } from "lucide-react";
 import { type Player, PlayerStatus } from "shared-types";
 import {
   useUIActorRef,
@@ -18,6 +18,8 @@ interface RoundSummaryProps {
   localPlayerId: string;
   /** Cumulative wins per player across rounds in this lobby. */
   playerWins: Record<string, number>;
+  /** Cumulative round scores, same lifetime as playerWins. Lower is better. */
+  playerTotals: Record<string, number>;
   /** Non-host players who have signalled they want a rematch (advisory tally). */
   rematchVotes: string[];
   onPlayAgain: () => void;
@@ -71,6 +73,7 @@ export const RoundSummary = ({
   winnerIds,
   localPlayerId,
   playerWins,
+  playerTotals,
   rematchVotes,
   onPlayAgain,
   onRequestPlayAgain,
@@ -97,7 +100,23 @@ export const RoundSummary = ({
     : `${rematchCount > 0 ? `${rematchCount}/${nonHostCount} in · ` : ""}Waiting for the host to start`;
 
   const winners = players.filter((p) => winnerIds.includes(p.id));
-  const sorted = [...players].sort((a, b) => a.score - b.score);
+  // Rows answer "what happened this round", so they follow this round's score
+  // and the headline above them. The series is the tiebreak, never the key:
+  // ordering rows by the standing would put the crown on row four.
+  const sorted = [...players].sort(
+    (a, b) =>
+      a.score - b.score ||
+      (playerTotals[a.id] ?? 0) - (playerTotals[b.id] ?? 0),
+  );
+
+  // The standing is the other question, so it gets the other order. Wins
+  // first, because a round is the unit of play; the total only separates
+  // players on equal wins, which at six players is most of them.
+  const standing = [...players].sort(
+    (a, b) =>
+      (playerWins[b.id] ?? 0) - (playerWins[a.id] ?? 0) ||
+      (playerTotals[a.id] ?? 0) - (playerTotals[b.id] ?? 0),
+  );
   const caller = callerId ? players.find((p) => p.id === callerId) : null;
 
   // A shared lowest score is a tie, not a group of separate winners: name it
@@ -267,21 +286,6 @@ export const RoundSummary = ({
                         </span>
                       )}
                     </span>
-                    {/* Series wins, on every row so a six player table can see
-                    the whole standing. Trophy rather than the Crown above it:
-                    the crown marks who took THIS round, the trophy the series,
-                    and the two would otherwise read as the same number. The
-                    guard only bites on a round that produced no winner at all,
-                    since this round's is credited before the sheet mounts. */}
-                    {seriesStarted && (
-                      <span
-                        className="flex shrink-0 items-center gap-1 text-sm font-semibold tabular-nums text-ink-muted"
-                        aria-label={`${playerWins[player.id] ?? 0} rounds won this series`}
-                      >
-                        <Trophy className="h-3.5 w-3.5" aria-hidden />
-                        {playerWins[player.id] ?? 0}
-                      </span>
-                    )}
                     <ScoreStamp
                       value={player.score}
                       delay={FIRST_STAMP_DELAY_S + i * STAMP_STAGGER_S}
@@ -291,6 +295,41 @@ export const RoundSummary = ({
                 );
               })}
             </div>
+
+            {/* The series, once, as a summary rather than a second table. It
+                used to ride on every row as a trophy, which stated the same
+                fact six times and read as a rival to the round's own score.
+                "wins" is spelled out on the leader only: the unit is named
+                once and the rest are read against it. */}
+            {seriesStarted && (
+              <div className="mt-4">
+                <p className="text-xs font-semibold uppercase tracking-widest text-ink-muted">
+                  Standing
+                </p>
+                <div className="mt-1.5 flex flex-wrap gap-x-4 gap-y-1">
+                  {standing.map((player, i) => (
+                    <span
+                      key={player.id}
+                      className="text-sm text-ink-muted"
+                      aria-label={`${player.name}, ${playerWins[player.id] ?? 0} rounds won, ${playerTotals[player.id] ?? 0} points across the series`}
+                    >
+                      <span className="tabular-nums">{i + 1}</span>{" "}
+                      <span className="font-semibold text-ink">
+                        {player.name}
+                      </span>{" "}
+                      <span className="tabular-nums">
+                        {playerWins[player.id] ?? 0}
+                        {i === 0 &&
+                          ((playerWins[player.id] ?? 0) === 1
+                            ? " win"
+                            : " wins")}{" "}
+                        · {playerTotals[player.id] ?? 0}
+                      </span>
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
           </div>
           {moreBelow && (
             <div

--- a/client/components/game/RoundSummary.tsx
+++ b/client/components/game/RoundSummary.tsx
@@ -142,7 +142,9 @@ export const RoundSummary = ({
   // else, so it now rides on the rows instead, where every player already has
   // one.
   const roundNumber = roundEpoch + 1;
-  const seriesStarted = players.some((p) => (playerWins[p.id] ?? 0) > 0);
+  // A series needs a round to compare against. The epoch counts Play Agains,
+  // so it is still 0 on the first end screen and 1 on the second.
+  const seriesHistory = roundEpoch > 0;
 
   // A panel that scrolls with nothing to say so reads as a list that ended,
   // and at a full table the rows below the fold are most of the result. The
@@ -296,38 +298,38 @@ export const RoundSummary = ({
               })}
             </div>
 
-            {/* The series, once, as a summary rather than a second table. It
-                used to ride on every row as a trophy, which stated the same
-                fact six times and read as a rival to the round's own score.
-                "wins" is spelled out on the leader only: the unit is named
-                once and the rest are read against it. */}
-            {seriesStarted && (
-              <div className="mt-4">
-                <p className="text-xs font-semibold uppercase tracking-widest text-ink-muted">
-                  Standing
-                </p>
-                <div className="mt-1.5 flex flex-wrap gap-x-4 gap-y-1">
-                  {standing.map((player, i) => (
-                    <span
-                      key={player.id}
-                      className="text-sm text-ink-muted"
-                      aria-label={`${player.name}, ${playerWins[player.id] ?? 0} rounds won, ${playerTotals[player.id] ?? 0} points across the series`}
-                    >
-                      <span className="tabular-nums">{i + 1}</span>{" "}
-                      <span className="font-semibold text-ink">
-                        {player.name}
-                      </span>{" "}
-                      <span className="tabular-nums">
-                        {playerWins[player.id] ?? 0}
-                        {i === 0 &&
-                          ((playerWins[player.id] ?? 0) === 1
-                            ? " win"
-                            : " wins")}{" "}
-                        · {playerTotals[player.id] ?? 0}
-                      </span>
-                    </span>
-                  ))}
+            {/* Only from the second round. After the first, the series IS the
+                result directly above it, restated in a worse format with a
+                column of zeroes for a total nothing has accumulated into.
+                Columns line up with the rows above and with the side panel's
+                tab, so the same board reads the same way wherever it is. */}
+            {seriesHistory && (
+              <div className="mt-4 border-t border-hairline pt-3">
+                <div className="flex items-baseline gap-3 text-[11px] font-semibold uppercase tracking-widest text-ink-muted">
+                  <span className="w-5 shrink-0" aria-hidden />
+                  <span className="min-w-0 flex-1">Series</span>
+                  <span className="w-10 shrink-0 text-right">Wins</span>
+                  <span className="w-12 shrink-0 text-right">Total</span>
                 </div>
+                {standing.map((player, i) => (
+                  <div
+                    key={player.id}
+                    className="flex items-center gap-3 py-1 text-sm"
+                  >
+                    <span className="w-5 shrink-0 font-semibold tabular-nums text-ink-muted">
+                      {i + 1}
+                    </span>
+                    <span className="min-w-0 flex-1 truncate font-semibold text-ink">
+                      {player.name}
+                    </span>
+                    <span className="w-10 shrink-0 text-right font-semibold tabular-nums text-ink-muted">
+                      {playerWins[player.id] ?? 0}
+                    </span>
+                    <span className="w-12 shrink-0 text-right font-bold tabular-nums text-ink">
+                      {playerTotals[player.id] ?? 0}
+                    </span>
+                  </div>
+                ))}
               </div>
             )}
           </div>

--- a/client/components/game/RoundSummary.tsx
+++ b/client/components/game/RoundSummary.tsx
@@ -215,7 +215,17 @@ export const RoundSummary = ({
             phone the heading costs as much as the whole row list, and pinning
             it too leaves the sheet with no room to show a single score. */}
         <div className="relative flex min-h-0 flex-1 flex-col">
-          <div ref={listRef} className="min-h-0 flex-1 overflow-y-auto">
+          {/* overflow-x-hidden is load-bearing. Asking for overflow-y auto
+              turns the other axis auto too, and the score stamps land from
+              scale 1.12 flush against this box's right edge, so the arrival
+              flashed a horizontal scrollbar for as long as the spring ran. */}
+          {/* pr-3 is the scrollbar's lane. The sheet's padding sits on the box
+              outside this one, so without it the scores are printed under the
+              bar rather than beside it. */}
+          <div
+            ref={listRef}
+            className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden pr-3"
+          >
             <div>
               <p className="truncate text-xs font-semibold uppercase tracking-widest text-ink-muted">
                 Round {roundNumber}

--- a/client/components/layout/SidePanel.tsx
+++ b/client/components/layout/SidePanel.tsx
@@ -170,6 +170,7 @@ export const SidePanel = () => {
         seat(a.id) - seat(b.id),
     );
   }, [players, turnOrder, playerWins, playerTotals]);
+  const scored = standing.some((p) => (playerWins?.[p.id] ?? 0) > 0);
 
   // Group consecutive same-sender messages within two minutes: one timestamp
   // per group, on its last message.
@@ -267,18 +268,28 @@ export const SidePanel = () => {
               {/* The round number lives here and nowhere else during play, so
                   in a long session this is the only way to tell round three
                   from round eleven. */}
-              <div className="flex items-baseline justify-between">
-                <p className="text-xs font-semibold uppercase tracking-widest text-ink-muted">
-                  Standing
+              <p className="text-sm font-bold text-ink">
+                Round {(roundEpoch ?? 0) + 1}
+              </p>
+              {/* Only while every column is a zero. The table already says who
+                  is here; this says why it has nothing in it yet, which a
+                  column of zeroes on its own reads as a bug. */}
+              {!scored && (
+                <p className="mt-0.5 text-xs text-ink-muted">
+                  Fills in as rounds are scored.
                 </p>
-                <p className="text-xs font-semibold uppercase tracking-widest text-ink-muted">
-                  Round {(roundEpoch ?? 0) + 1}
-                </p>
+              )}
+              {/* Same columns as the end screen's block, in the same order, so
+                  the two are recognisably one board. Rendered from round one,
+                  zeros and all: a table of names with nothing won yet still
+                  says who is here and what it will fill in. */}
+              <div className="mt-3 flex items-baseline gap-3 text-[11px] font-semibold uppercase tracking-widest text-ink-muted">
+                <span className="w-4 shrink-0" aria-hidden />
+                <span className="min-w-0 flex-1">Player</span>
+                <span className="w-10 shrink-0 text-right">Wins</span>
+                <span className="w-12 shrink-0 text-right">Total</span>
               </div>
-              {/* Rendered from round one, zeros and all. A table of names with
-                  nothing won yet still says who is here and what it will fill
-                  in; an empty panel says neither. */}
-              <div className="mt-2 divide-y divide-hairline">
+              <div className="divide-y divide-hairline">
                 {standing.map((player, i) => (
                   <div key={player.id} className="flex items-center gap-3 py-2">
                     <span className="w-4 shrink-0 text-sm font-semibold tabular-nums text-ink-muted">
@@ -292,11 +303,10 @@ export const SidePanel = () => {
                         </span>
                       )}
                     </span>
-                    <span className="shrink-0 text-sm font-semibold tabular-nums text-ink-muted">
-                      {playerWins?.[player.id] ?? 0}{" "}
-                      {(playerWins?.[player.id] ?? 0) === 1 ? "win" : "wins"}
+                    <span className="w-10 shrink-0 text-right text-sm font-semibold tabular-nums text-ink-muted">
+                      {playerWins?.[player.id] ?? 0}
                     </span>
-                    <span className="w-10 shrink-0 text-right text-sm font-bold tabular-nums text-ink">
+                    <span className="w-12 shrink-0 text-right text-sm font-bold tabular-nums text-ink">
                       {playerTotals?.[player.id] ?? 0}
                     </span>
                   </div>

--- a/client/components/layout/SidePanel.tsx
+++ b/client/components/layout/SidePanel.tsx
@@ -34,6 +34,7 @@ const selectSidePanelProps = (state: UIMachineSnapshot) => ({
   chat: state.context.currentGameState?.chat,
   localPlayerId: state.context.localPlayerId,
   players: state.context.currentGameState?.players,
+  turnOrder: state.context.currentGameState?.turnOrder,
   playerWins: state.context.currentGameState?.playerWins,
   playerTotals: state.context.currentGameState?.playerTotals,
   roundEpoch: state.context.currentGameState?.roundEpoch,
@@ -103,6 +104,7 @@ export const SidePanel = () => {
     chat,
     localPlayerId,
     players,
+    turnOrder,
     playerWins,
     playerTotals,
     roundEpoch,
@@ -151,17 +153,23 @@ export const SidePanel = () => {
   };
 
   // Same order as the end screen's block, so the two read as one board at two
-  // densities: wins first, the lower total separating equal wins.
+  // densities: wins first, the lower total separating equal wins. Seat order
+  // settles the rest, which is the whole table in round one and is why this
+  // list does not reshuffle itself every time a broadcast arrives.
   const standing = useMemo(() => {
     const wins = playerWins ?? {};
     const totals = playerTotals ?? {};
+    const seat = (id: string) => {
+      const i = (turnOrder ?? []).indexOf(id);
+      return i === -1 ? Number.MAX_SAFE_INTEGER : i;
+    };
     return Object.values(players ?? {}).sort(
       (a, b) =>
         (wins[b.id] ?? 0) - (wins[a.id] ?? 0) ||
-        (totals[a.id] ?? 0) - (totals[b.id] ?? 0),
+        (totals[a.id] ?? 0) - (totals[b.id] ?? 0) ||
+        seat(a.id) - seat(b.id),
     );
-  }, [players, playerWins, playerTotals]);
-  const seriesStarted = standing.some((p) => (playerWins?.[p.id] ?? 0) > 0);
+  }, [players, turnOrder, playerWins, playerTotals]);
 
   // Group consecutive same-sender messages within two minutes: one timestamp
   // per group, on its last message.
@@ -267,39 +275,33 @@ export const SidePanel = () => {
                   Round {(roundEpoch ?? 0) + 1}
                 </p>
               </div>
-              {seriesStarted ? (
-                <div className="mt-2 divide-y divide-hairline">
-                  {standing.map((player, i) => (
-                    <div
-                      key={player.id}
-                      className="flex items-center gap-3 py-2"
-                    >
-                      <span className="w-4 shrink-0 text-sm font-semibold tabular-nums text-ink-muted">
-                        {i + 1}
-                      </span>
-                      <span className="min-w-0 flex-1 truncate text-sm font-bold text-ink">
-                        {player.name}
-                        {player.id === localPlayerId && (
-                          <span className="ml-1.5 text-xs font-normal text-ink-muted">
-                            (you)
-                          </span>
-                        )}
-                      </span>
-                      <span className="shrink-0 text-sm font-semibold tabular-nums text-ink-muted">
-                        {playerWins?.[player.id] ?? 0}{" "}
-                        {(playerWins?.[player.id] ?? 0) === 1 ? "win" : "wins"}
-                      </span>
-                      <span className="w-10 shrink-0 text-right text-sm font-bold tabular-nums text-ink">
-                        {playerTotals?.[player.id] ?? 0}
-                      </span>
-                    </div>
-                  ))}
-                </div>
-              ) : (
-                <p className="pt-2 text-xs font-semibold uppercase tracking-widest text-ink-muted">
-                  After the first round
-                </p>
-              )}
+              {/* Rendered from round one, zeros and all. A table of names with
+                  nothing won yet still says who is here and what it will fill
+                  in; an empty panel says neither. */}
+              <div className="mt-2 divide-y divide-hairline">
+                {standing.map((player, i) => (
+                  <div key={player.id} className="flex items-center gap-3 py-2">
+                    <span className="w-4 shrink-0 text-sm font-semibold tabular-nums text-ink-muted">
+                      {i + 1}
+                    </span>
+                    <span className="min-w-0 flex-1 truncate text-sm font-bold text-ink">
+                      {player.name}
+                      {player.id === localPlayerId && (
+                        <span className="ml-1.5 text-xs font-normal text-ink-muted">
+                          (you)
+                        </span>
+                      )}
+                    </span>
+                    <span className="shrink-0 text-sm font-semibold tabular-nums text-ink-muted">
+                      {playerWins?.[player.id] ?? 0}{" "}
+                      {(playerWins?.[player.id] ?? 0) === 1 ? "win" : "wins"}
+                    </span>
+                    <span className="w-10 shrink-0 text-right text-sm font-bold tabular-nums text-ink">
+                      {playerTotals?.[player.id] ?? 0}
+                    </span>
+                  </div>
+                ))}
+              </div>
             </div>
           ) : (
             <div className="flex min-h-0 flex-1 flex-col">

--- a/client/components/layout/SidePanel.tsx
+++ b/client/components/layout/SidePanel.tsx
@@ -11,6 +11,7 @@ import {
   Send,
   Shuffle,
   Sparkles,
+  Trophy,
   X,
   type LucideIcon,
 } from "lucide-react";
@@ -25,13 +26,17 @@ const MAX_CHAT_MESSAGE_LENGTH = 500;
 const TAB_KEY = "check:panel-tab";
 const GROUP_WINDOW_MS = 2 * 60 * 1000;
 
-type Tab = "activity" | "chat";
+type Tab = "activity" | "chat" | "standings";
 
 const selectSidePanelProps = (state: UIMachineSnapshot) => ({
   isOpen: state.context.isSidePanelOpen,
   log: state.context.currentGameState?.log,
   chat: state.context.currentGameState?.chat,
   localPlayerId: state.context.localPlayerId,
+  players: state.context.currentGameState?.players,
+  playerWins: state.context.currentGameState?.playerWins,
+  playerTotals: state.context.currentGameState?.playerTotals,
+  roundEpoch: state.context.currentGameState?.roundEpoch,
 });
 
 const formatTime = (timestamp: string) => {
@@ -92,8 +97,16 @@ const TabChip = ({
 
 export const SidePanel = () => {
   const { send } = useUIActorRef();
-  const { isOpen, log, chat, localPlayerId } =
-    useUISelector(selectSidePanelProps);
+  const {
+    isOpen,
+    log,
+    chat,
+    localPlayerId,
+    players,
+    playerWins,
+    playerTotals,
+    roundEpoch,
+  } = useUISelector(selectSidePanelProps);
   const [draft, setDraft] = useState("");
   const [tab, setTab] = useState<Tab>(() => {
     if (typeof window === "undefined") return "activity";
@@ -136,6 +149,19 @@ export const SidePanel = () => {
     send({ type: "SUBMIT_CHAT_MESSAGE", message });
     setDraft("");
   };
+
+  // Same order as the end screen's block, so the two read as one board at two
+  // densities: wins first, the lower total separating equal wins.
+  const standing = useMemo(() => {
+    const wins = playerWins ?? {};
+    const totals = playerTotals ?? {};
+    return Object.values(players ?? {}).sort(
+      (a, b) =>
+        (wins[b.id] ?? 0) - (wins[a.id] ?? 0) ||
+        (totals[a.id] ?? 0) - (totals[b.id] ?? 0),
+    );
+  }, [players, playerWins, playerTotals]);
+  const seriesStarted = standing.some((p) => (playerWins?.[p.id] ?? 0) > 0);
 
   // Group consecutive same-sender messages within two minutes: one timestamp
   // per group, on its last message.
@@ -185,6 +211,13 @@ export const SidePanel = () => {
                 <MessageCircle className="h-3.5 w-3.5" />
                 Chat
               </TabChip>
+              <TabChip
+                active={tab === "standings"}
+                onClick={() => pickTab("standings")}
+              >
+                <Trophy className="h-3.5 w-3.5" />
+                Standing
+              </TabChip>
             </div>
             <button
               onClick={() => send({ type: "TOGGLE_SIDE_PANEL" })}
@@ -218,6 +251,53 @@ export const SidePanel = () => {
               ) : (
                 <p className="pt-2 text-xs font-semibold uppercase tracking-widest text-ink-muted">
                   Nothing yet
+                </p>
+              )}
+            </div>
+          ) : tab === "standings" ? (
+            <div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
+              {/* The round number lives here and nowhere else during play, so
+                  in a long session this is the only way to tell round three
+                  from round eleven. */}
+              <div className="flex items-baseline justify-between">
+                <p className="text-xs font-semibold uppercase tracking-widest text-ink-muted">
+                  Standing
+                </p>
+                <p className="text-xs font-semibold uppercase tracking-widest text-ink-muted">
+                  Round {(roundEpoch ?? 0) + 1}
+                </p>
+              </div>
+              {seriesStarted ? (
+                <div className="mt-2 divide-y divide-hairline">
+                  {standing.map((player, i) => (
+                    <div
+                      key={player.id}
+                      className="flex items-center gap-3 py-2"
+                    >
+                      <span className="w-4 shrink-0 text-sm font-semibold tabular-nums text-ink-muted">
+                        {i + 1}
+                      </span>
+                      <span className="min-w-0 flex-1 truncate text-sm font-bold text-ink">
+                        {player.name}
+                        {player.id === localPlayerId && (
+                          <span className="ml-1.5 text-xs font-normal text-ink-muted">
+                            (you)
+                          </span>
+                        )}
+                      </span>
+                      <span className="shrink-0 text-sm font-semibold tabular-nums text-ink-muted">
+                        {playerWins?.[player.id] ?? 0}{" "}
+                        {(playerWins?.[player.id] ?? 0) === 1 ? "win" : "wins"}
+                      </span>
+                      <span className="w-10 shrink-0 text-right text-sm font-bold tabular-nums text-ink">
+                        {playerTotals?.[player.id] ?? 0}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <p className="pt-2 text-xs font-semibold uppercase tracking-widest text-ink-muted">
+                  After the first round
                 </p>
               )}
             </div>

--- a/server/src/game-machine.ts
+++ b/server/src/game-machine.ts
@@ -1522,10 +1522,18 @@ export const gameMachine = setup({
         nextPlayerWins[id] = (nextPlayerWins[id] ?? 0) + 1;
       }
 
+      // Every player, not only the winners: a total is the sum of the rounds
+      // you played, and a disqualified player still scored one.
+      const nextPlayerTotals = { ...context.playerTotals };
+      for (const [id, score] of Object.entries(playerScores)) {
+        nextPlayerTotals[id] = (nextPlayerTotals[id] ?? 0) + score;
+      }
+
       return {
         players: updatedPlayers,
         winnerId: winnerIds[0] ?? null,
         playerWins: nextPlayerWins,
+        playerTotals: nextPlayerTotals,
         gameover: { winnerIds, loserId, playerScores },
         gameStage: GameStage.SCORING,
         publicPeek: null,
@@ -1855,6 +1863,10 @@ export const gameMachine = setup({
         if (winnerId) {
           nextPlayerWins[winnerId] = (nextPlayerWins[winnerId] ?? 0) + 1;
         }
+        const nextPlayerTotals = { ...context.playerTotals };
+        for (const [id, score] of Object.entries(playerScores)) {
+          nextPlayerTotals[id] = (nextPlayerTotals[id] ?? 0) + score;
+        }
         return {
           players: newPlayers,
           turnOrder: newTurnOrder,
@@ -1865,6 +1877,7 @@ export const gameMachine = setup({
           gameStage: GameStage.GAMEOVER,
           winnerId,
           playerWins: nextPlayerWins,
+          playerTotals: nextPlayerTotals,
           gameover: {
             winnerIds: winnerId ? [winnerId] : [],
             loserId: affectedPlayerId,
@@ -2082,6 +2095,7 @@ export const gameMachine = setup({
     gameover: null,
     lastRoundLoserId: null,
     playerWins: {},
+    playerTotals: {},
     rematchVotes: [],
     roundEpoch: 0,
     log: [],

--- a/server/src/state-redactor.ts
+++ b/server/src/state-redactor.ts
@@ -146,6 +146,11 @@ export const generatePlayerView = (
         ([id]) => !!fullGameContext.players[id],
       ),
     ),
+    playerTotals: Object.fromEntries(
+      Object.entries(fullGameContext.playerTotals ?? {}).filter(
+        ([id]) => !!fullGameContext.players[id],
+      ),
+    ),
     // Filter to players still at the table so a voter who left doesn't inflate
     // the tally (votes are also reset each new round).
     rematchVotes: fullGameContext.rematchVotes.filter(

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -71,6 +71,10 @@ export interface GameContext {
    *  scores this survives resetForNewRound; the redactor drops entries for
    *  players who have left. */
   playerWins: Record<PlayerId, number>;
+  /** Cumulative round scores per player, accumulated and surviving exactly as
+   *  playerWins does. Every player is credited each round, disqualified ones
+   *  included, since a total is the sum of the rounds you played. */
+  playerTotals: Record<PlayerId, number>;
   /** Players who signalled "play again" at GAMEOVER (advisory rematch tally;
    *  the host still starts the round). Reset each new round. */
   rematchVotes: PlayerId[];

--- a/shared-types/src/index.ts
+++ b/shared-types/src/index.ts
@@ -173,6 +173,10 @@ export interface ClientCheckGameState {
   /** Cumulative round wins per player for this lobby's lifetime. Survives
    *  Play Again (unlike scores); only players still at the table appear. */
   playerWins: Record<PlayerId, number>;
+  /** Cumulative round scores per player, same lifetime and same survival as
+   *  playerWins. Lower is better, consistently with a round score. Ordering
+   *  only: wins decide the standing and this breaks their ties. */
+  playerTotals: Record<PlayerId, number>;
   /** Players (at GAMEOVER) who signalled they want to play again — a live
    *  rematch tally shown to everyone. The host still starts the next round
    *  via PLAY_AGAIN; this is advisory. Reset on each new round. */

--- a/tools/probe/probe.mjs
+++ b/tools/probe/probe.mjs
@@ -45,6 +45,9 @@ const opts = {
   shift: flag("shift"),
   sweep: flag("sweep"),
   scrolled: flag("scrolled"),
+  film: flag("film"),
+  filmFrames: Number(arg("frames", 16)),
+  filmEveryMs: Number(arg("frame-ms", 120)),
   matrix: flag("matrix"),
   counts: arg("counts", "2,4,6"),
   states: arg("states", "lobby,play,drawn,matching,scoring"),
@@ -360,7 +363,23 @@ const drive = async (page, opts) => {
     // first gets photographed at whatever this wait allows, so anything
     // shorter than the whole sequence produces a shot of the smallest screen
     // with its last rows blank, which reads as scores that failed to render.
-    await page.waitForTimeout(3000);
+    // A settled screenshot cannot see anything that only exists while the view
+    // is arriving, and the end screen spends its first seconds animating: the
+    // sheet climbs, the scores stamp, the board is still finishing its flights.
+    // Filming it is the only way to look at that window.
+    if (opts.film) {
+      const filmDir = join(ROOT, opts.out);
+      mkdirSync(filmDir, { recursive: true });
+      for (let i = 0; i < opts.filmFrames; i++) {
+        await page.screenshot({
+          path: join(filmDir, `film-${String(i).padStart(2, "0")}.png`),
+        });
+        await page.waitForTimeout(opts.filmEveryMs);
+      }
+      console.log(`${opts.filmFrames} frames -> ${filmDir}`);
+    } else {
+      await page.waitForTimeout(3000);
+    }
     return { gameId, bots, observedId };
   }
 


### PR DESCRIPTION
Closes #103. Supersedes #105, which GitHub closed when its base branch was deleted on merging #104. Same commits, rebased onto main.

## Server

`playerTotals`, a running sum of each player's round scores, accumulated and surviving Play Again exactly as `playerWins` does, which is why `resetForNewRound` mentions neither. Both scoring paths credit it, including the one the machine already notes never runs `calculateScores`.

Every player is credited, disqualified ones included. A total that counted only winners would rank everyone who has never won as equal, which is the one job it has.

It has to be the server: a client accumulating in memory loses the series on a refresh and has nothing to send back on reconnect.

## End screen

Rows answer what happened this round: this round's score, lowest first, with the series as a tiebreak only. Ordering rows by the standing would put the crown on row four.

The series is a small aligned table below them, sharing its columns with the side panel's tab so one board reads the same way wherever it is found. It appears from the second round: after the first, the series is the result printed directly above it with a column of zeroes for a total nothing has accumulated into.

## Side panel

A third tab, same sort and same columns, with full rows since the panel has the vertical room the sheet does not. It leads with the round number, which nothing else shows during play, and renders from round one so the table says who is at the table before anyone has won anything.

## Two scrollbar faults from moving the padding

The sheet's horizontal padding sits on the box outside the scroller, which left the list running flush to the edge a scrollbar occupies. The scores were set against the bar, and the score stamps, landing from `scale: 1.12`, reached past that edge for as long as their spring ran. Since asking for `overflow-y: auto` makes the other axis auto too, that overhang flashed a horizontal scrollbar across the end screen on every arrival.

Both reported by the owner. Neither is visible to a settled screenshot, which is why `--film` now captures the arrival frame by frame.

## Verification

`.remember/repro-series-totals.mjs` drives the real compiled machine through two rounds and a Play Again. Red before the change (`totals {}`, every value `undefined`), green after: totals equal the sum of the rounds played, survive the reset, and round scores clear. Confirmed red by stashing the server change and rebuilding, not by reading it.

`repro-state-redactor.mjs` still passes all seven checks, since `state-redactor.ts` was touched.

`npm run probe -- --at scoring --players 6`: seven viewports, all controls reachable, no covered cards, no starved panel. Typecheck, lint and format clean after the rebase.

## Known

The round-two end screen and the panel tab have not been watched in a browser with the scrollbar fixes in place, and a Vercel preview cannot verify the server half at all, since it deploys the client only and talks to whatever server is on main. Two rounds on production after this lands is the check that matters.