### PR TITLE
Log the two states a frozen client cannot report itself

### DIFF
--- a/client/app/providers.tsx
+++ b/client/app/providers.tsx
@@ -41,6 +41,7 @@ type AbilityPeekResultPayload = Parameters<
 // ============================================================================
 function UIMachineEffects({ actor }: { actor: UIMachineActorRef }) {
   const router = useRouter();
+  const lastStateAt = useRef(0);
 
   useEffect(() => {
     type EmittedEvent = Parameters<Parameters<typeof actor.on>[1]>[0];
@@ -63,8 +64,10 @@ function UIMachineEffects({ actor }: { actor: UIMachineActorRef }) {
     });
 
     // Socket → Actor bridges
-    const gs = (g: ClientCheckGameState) =>
+    const gs = (g: ClientCheckGameState) => {
+      lastStateAt.current = Date.now();
       actor.send({ type: "CLIENT_GAME_STATE_UPDATED", gameState: g });
+    };
     const lg = (m: RichGameLogMessage) =>
       actor.send({ type: "NEW_GAME_LOG", logMessage: m });
     const cm = (m: ChatMessage) =>
@@ -87,7 +90,21 @@ function UIMachineEffects({ actor }: { actor: UIMachineActorRef }) {
         type: "CONNECT",
         recovered: (socket as { recovered?: boolean }).recovered === true,
       });
-    const onDisconnect = () => actor.send({ type: "DISCONNECT" });
+    const onDisconnect = (reason: string) => {
+      // The server stops broadcasting the moment it writes a player off, which
+      // can be well before this side's ping timeout fires. How long the board
+      // had already been frozen is the measurement that separates the two.
+      logger.warn(
+        {
+          reason,
+          boardStaleForMs: lastStateAt.current
+            ? Date.now() - lastStateAt.current
+            : null,
+        },
+        "Socket disconnected",
+      );
+      actor.send({ type: "DISCONNECT" });
+    };
 
     socket.on(SocketEventName.GAME_STATE_UPDATE, gs);
     socket.on(SocketEventName.SERVER_LOG_ENTRY, lg);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -179,6 +179,17 @@ io.on("connection", (socket: Socket) => {
           SocketEventName.GAME_STATE_UPDATE,
           generatePlayerView(snapshot, player.id),
         );
+        return;
+      }
+      // Skipping a player whose transport is still open is the one shape worth
+      // hearing about: they sit in front of a frozen board while everyone else
+      // plays on, and nothing on their side knows yet. Guarded on the live
+      // socket so an ordinary departure stays silent.
+      if (player.socketId && io.sockets.sockets.has(player.socketId)) {
+        logger.warn(
+          { gameId, playerId: player.id, socketId: player.socketId },
+          "Skipped a broadcast to a player whose socket is still connected",
+        );
       }
     });
   };
@@ -544,6 +555,22 @@ io.on("connection", (socket: Socket) => {
       }
       const gameActor = activeGameMachines.get(session.gameId);
       if (!gameActor) return;
+
+      // The other half of the same picture: input still arriving from someone
+      // the machine has written off. Their action moves the game for everyone
+      // else while no result reaches them.
+      if (
+        !gameActor.getSnapshot().context.players[session.playerId]?.isConnected
+      ) {
+        logger.warn(
+          {
+            gameId: session.gameId,
+            playerId: session.playerId,
+            actionType: action?.type,
+          },
+          "Player action from a player the server considers disconnected",
+        );
+      }
 
       if (!action || !ALLOWED_PLAYER_ACTIONS.has(action.type)) {
         logger.warn(


### PR DESCRIPTION
Groundwork for #56, and the first step before touching the freezes reported in real games. Instrumentation only, no behaviour change.

## Why these two lines

A frozen client cannot report its own freeze, and nothing in production currently says why a board stopped updating. These are the cheapest signals that would have made the last few reports diagnosable instead of anecdotal.

**Server, on a skipped broadcast.** `broadcastGameState` only emits to players it believes are connected. Skipping a player whose socket is *still open* is the one shape worth hearing about: the machine's view of who is present has drifted from socket.io's, and someone is sitting in front of a board that will never update. The guard on the live socket keeps an ordinary departure silent, so this line only appears when something is genuinely wrong.

**Server, on an action from a player it has written off.** The other half of the same picture. Input still arriving from someone excluded from every broadcast means their play is moving the game for everyone else while nothing comes back to them.

**Client, on disconnect.** Records how long the board had been stale when the socket finally reported the drop. That number is the freeze the player actually sat through, and it is the one measurement no server-side log can produce.

## What the last of those is worth

While preparing this I measured the freeze against the real server, with a TCP proxy that stops passing bytes in both directions while holding the sockets open, which is what an expiring NAT mapping or a phone changing radio does:

```
blackout began            t0+26043ms
server wrote the player off  +44393ms into the blackout
their client gave up         +43998ms into the blackout
updates received during it   0
```

Forty four seconds of dead board, socket reporting `connected` throughout, nothing on screen. Both sides land on the same number because engine.io's server waits `pingInterval` from the last pong and then `pingTimeout` (`engine.io/build/socket.js:138,149`), while the client arms `pingInterval + pingTimeout` from the last ping it saw. 25 + 20 either way.

`boardStaleForMs` is that number, reported from production instead of from a lab.

## Verification

`npm run verify` passes end to end. The repro scripts behind the measurement live in `.remember/` and are not part of this change.

No behaviour changes: three log statements and one ref.
