### PR TITLE
Refuse a move instead of burying it in the reconnect buffer

### DIFF
--- a/client/app/providers.tsx
+++ b/client/app/providers.tsx
@@ -49,6 +49,14 @@ function UIMachineEffects({ actor }: { actor: UIMachineActorRef }) {
     const socketSub = actor.on("EMIT_TO_SOCKET", (emitted: EmittedEvent) => {
       if (emitted.type !== "EMIT_TO_SOCKET") return;
       if (emitted.eventName === SocketEventName.PLAYER_ACTION) {
+        // Never hand a move to a disconnected socket. socket.io buffers it and
+        // flushes on reconnect BEFORE the connect handler below can rejoin, so
+        // it lands with no session and the server discards it. Replaying it
+        // later would be worse: the board has moved on by then.
+        if (!socket.connected) {
+          actor.send({ type: "ACTION_NOT_SENT" });
+          return;
+        }
         socket.emit(emitted.eventName, emitted.payload as PlayerActionPayload);
       } else {
         logger.warn(

--- a/client/machines/uiMachine.ts
+++ b/client/machines/uiMachine.ts
@@ -106,6 +106,7 @@ export type UIMachineEvents =
       playerId: PlayerId;
       cardIndex: number;
     }
+  | { type: "ACTION_NOT_SENT" }
   | { type: "CONFIRM_ABILITY_ACTION" }
   | { type: "SKIP_ABILITY_STAGE" }
   | { type: "TOGGLE_SIDE_PANEL" }
@@ -743,6 +744,19 @@ export const uiMachine = setup({
       ],
     },
     ERROR_RECEIVED: { actions: "showErrorToast" },
+    // The bridge refused to put a move on a dead socket. Clear the in-flight
+    // state now rather than letting the action bar grey out for its full
+    // unstick delay over a move that was never sent.
+    ACTION_NOT_SENT: {
+      actions: [
+        assign({ pendingActionSince: null }),
+        () =>
+          toast.error("Move not sent", {
+            description:
+              "You are not connected right now. Try again in a moment.",
+          }),
+      ],
+    },
   },
   states: {
     initializing: {


### PR DESCRIPTION
Part of #122, the second of its four parts. Does not close it.

## What was happening

Clicking while the connection was down looked like it worked, and then quietly did not.

`socket.io-client` buffers an emit made while disconnected and flushes it on reconnect. The flush runs inside `onconnect()` **before** the `connect` event fires (`socket.io-client/build/cjs/socket.js:610-632`), and the `connect` event is what makes the bridge send `ATTEMPT_REJOIN`, which is what registers the session. So the move landed on a socket id the server had no session for and was dropped.

Reproduced against the real server before writing the fix:

```
[disconnected] clicked Ready (socket.io buffers it)
WARN  socketId:"H07YiXGgcK38pdxmAAAH"  "Player action received from socket without a session."
[reconnected] Alice ready: false
[after retry]  Alice ready: true
```

Delivered, arrived before the session existed, discarded. The identical action works once seated, so this was purely about ordering. The warn line is the one added in #120, doing exactly the job it was added for.

## The change

The bridge refuses to hand a move to a socket that cannot carry it, and tells the player instead. The machine clears the in-flight marker on refusal, so the action bar does not sit greyed for its full four second unstick over a move that was never sent.

Replaying the move after the rejoin would be worse than losing it. By the time the socket is back the board has moved on, and a draw or a match replayed against a different position is a bug with sharper teeth than a lost click. Refusing and saying so is the honest outcome.

## Verification

`npm run verify` passes end to end.

The server half of this was measured, both before the fix and as the reason for it, with a repro kept outside the repo.

Being straight about the client half: the four line gate in the bridge is verified by typecheck and by reading, not by a running test, because it lives in a React component and would need a browser. The machine half was exercised against the real `uiMachine`, confirming the refusal is handled at the machine root and so reachable from every state. That check is weaker than it looks, since `pendingActionSince` is already null in the state it could be driven to outside a game.

Worth a live look: go offline, press something, and confirm the toast appears and the button does not hang.
