### PR TITLE
Notice a dead connection in seconds rather than most of a minute

### DIFF
--- a/client/machines/uiMachine.ts
+++ b/client/machines/uiMachine.ts
@@ -31,6 +31,10 @@ import logger from "@/lib/logger";
 import { createGameActor, joinGameActor, rejoinActor } from "@/lib/actors";
 
 const PEEK_ABILITY_DURATION_MS = 5000;
+// How long a move may go unanswered before we stop trusting the connection.
+// Every player action ends in a broadcast, so silence this long means the
+// server has stopped talking to us while the socket has not yet noticed.
+const ACTION_ANSWER_TIMEOUT_MS = 8000;
 const INITIAL_PEEK_DURATION_MS = 10000;
 
 type ServerToClientEvents =
@@ -107,6 +111,7 @@ export type UIMachineEvents =
       cardIndex: number;
     }
   | { type: "ACTION_NOT_SENT" }
+  | { type: "ACTION_UNANSWERED" }
   | { type: "CONFIRM_ABILITY_ACTION" }
   | { type: "SKIP_ABILITY_STAGE" }
   | { type: "TOGGLE_SIDE_PANEL" }
@@ -322,7 +327,13 @@ export const uiMachine = setup({
       reconnectionAttempts: 0,
       pendingActionSince: null,
     }),
-    markActionPending: assign({ pendingActionSince: () => Date.now() }),
+    markActionPending: enqueueActions(({ enqueue }) => {
+      enqueue.assign({ pendingActionSince: () => Date.now() });
+      enqueue.raise(
+        { type: "ACTION_UNANSWERED" },
+        { delay: ACTION_ANSWER_TIMEOUT_MS, id: "actionAnswerWatchdog" },
+      );
+    }),
     persistSession: ({ event }) => {
       assertEvent(event, "_SESSION_ESTABLISHED");
       if (
@@ -910,6 +921,19 @@ export const uiMachine = setup({
         },
         CLEANUP_EXPIRED_CARDS: { actions: "cleanupExpiredVisibleCards" },
         DISCONNECT: { target: ".disconnected" },
+        // A move nobody answered means the board is dead even though the
+        // socket still claims otherwise. Re-run the handshake instead of
+        // leaving the player pressing a button that does nothing. Guarded on
+        // the CURRENT wait so a stale timer from an answered move cannot fire.
+        ACTION_UNANSWERED: {
+          target: ".reconnecting",
+          guard: ({ context }) =>
+            context.pendingActionSince !== null &&
+            Date.now() - context.pendingActionSince >= ACTION_ANSWER_TIMEOUT_MS,
+        },
+        // Reachable from every game view, not just the lobby, so a player who
+        // can see something is wrong is never told to reload the page.
+        RETRY_REJOIN: { target: ".reconnecting" },
       },
       states: {
         routing: {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -153,6 +153,13 @@ export const io = new SocketIOServer<
     maxDisconnectionDuration: 2 * 60 * 1000, // 2 minutes buffer
     skipMiddlewares: true, // keep auth cost low during recovery
   },
+  // Both sides notice a dead link after pingInterval + pingTimeout, so the
+  // engine.io defaults (25s + 20s) leave a player staring at a frozen board
+  // for 45 seconds. Getting it wrong in this direction is the cheap mistake:
+  // recovery and the reconnect grace both run for minutes, so a premature
+  // disconnect costs a brief reconnecting flash and heals itself.
+  pingInterval: parseInt(process.env.SOCKET_PING_INTERVAL_MS || "10000", 10),
+  pingTimeout: parseInt(process.env.SOCKET_PING_TIMEOUT_MS || "8000", 10),
   // Game-state broadcasts are repetitive JSON that deflates 5-10×; slow
   // client links are the binding constraint, not server CPU. Frames under
   // 1 KB skip compression.


### PR DESCRIPTION
Closes the remaining three parts of #122: the detection window, the missing watchdog, and the missing in-game resync.

## The window

Both halves waited `pingInterval + pingTimeout`, so neither was faster than the other and neither said anything until the whole window expired. The engine.io defaults put that at 45 seconds.

The settings are now tunable, defaulting to 10s and 8s. Measured against the same black-holed connection that produced the original baseline, with a TCP proxy that stops passing bytes both ways while holding the sockets open:

```
before                                after
blackout began     t0+26043ms         blackout began     t0+12048ms
server wrote off   +44393ms           server wrote off   +16145ms
client gave up     +43998ms           client gave up     +15990ms
updates received   0                  updates received   0
```

44.0s down to 16.0s. Both sides stay symmetric, which is expected and fine.

Erring fast is the cheap direction here. Connection state recovery runs for two minutes and the reconnect grace for another two, so an early disconnect costs a brief reconnecting flash and heals itself, while a late one costs a dead board.

## The watchdog

Sixteen seconds is still a long time to stare at a frozen board, so a move that goes unanswered for eight seconds now re-runs the rejoin handshake on its own.

It keys on an **unanswered move**, not on elapsed silence. That distinction is the whole design: a player waiting on somebody else's turn is legitimately quiet for a long time, and a plain staleness timer would fire on them constantly. Every player action ends in a broadcast, so a move with no answer is a real signal.

Verified against the real `uiMachine`, both the firing and the not-firing:

```
after a move          : {"inGame":"lobby"}  pending: true
state now             : {"inGame":"reconnecting"}
watchdog fired after  : 8002ms

PASS an unanswered move re-runs the handshake instead of leaving the player stuck.
PASS a player who made no move is left alone.
```

The guard checks the current wait rather than merely that something is pending, so a stale timer left over from a move that was answered cannot fire.

## The resync

`RETRY_REJOIN` was handled in `lobby` and `disconnected` only, so during play the only escape from a frozen board was reloading the page. It is now handled at the `inGame` level and reachable from every game view.

A visible control for it is deliberately not in this PR. Where that lives is a design call, and the watchdog above means recovery no longer depends on the player finding a button.

## Verification

`npm run verify` passes end to end. Both measurements above come from repros kept outside the repo, run before and after.

Unverified: nobody has played a real game on the tighter ping window. The number to watch afterwards is `boardStaleForMs` from #120, which should now report seconds rather than the forties. If real mobile links turn out to produce false disconnects, `SOCKET_PING_INTERVAL_MS` and `SOCKET_PING_TIMEOUT_MS` move it without a code change.
