### PR TITLE
Make the entry handshakes answer, one way or another

### DIFF
--- a/client/lib/actors.ts
+++ b/client/lib/actors.ts
@@ -8,18 +8,29 @@ import {
   type InitialPlayerSetupData,
 } from "shared-types";
 
+// The ack timer starts when the packet is created, not when it is sent, so
+// this has to cover a cold start: the emit waits in socket.io's buffer until
+// the server is awake and the connection is up. A drop mid-flight does not
+// wait for it, because a timed emit is errored the moment the socket closes.
+const HANDSHAKE_TIMEOUT_MS = 60_000;
+const NO_ANSWER =
+  "The server did not answer. Check your connection and try again.";
+
 export const createGameActor = fromPromise<
   CreateGameResponse,
   { name: string; maxPlayers?: number }
 >(async ({ input }) => {
   return new Promise((resolve, reject) => {
-    socket.emit(SocketEventName.CREATE_GAME, input, (response) => {
-      if (response.success) {
-        resolve(response);
-      } else {
-        reject(new Error(response.message || "Failed to create game."));
-      }
-    });
+    socket
+      .timeout(HANDSHAKE_TIMEOUT_MS)
+      .emit(SocketEventName.CREATE_GAME, input, (err, response) => {
+        if (err) return reject(new Error(NO_ANSWER));
+        if (response.success) {
+          resolve(response);
+        } else {
+          reject(new Error(response.message || "Failed to create game."));
+        }
+      });
   });
 });
 
@@ -29,18 +40,21 @@ export const joinGameActor = fromPromise<
 >(async ({ input }) => {
   return new Promise((resolve, reject) => {
     const playerSetupData: InitialPlayerSetupData = { name: input.name };
-    socket.emit(
-      SocketEventName.JOIN_GAME,
-      input.gameId,
-      playerSetupData,
-      (response) => {
-        if (response.success) {
-          resolve(response);
-        } else {
-          reject(new Error(response.message || "Failed to join game."));
-        }
-      },
-    );
+    socket
+      .timeout(HANDSHAKE_TIMEOUT_MS)
+      .emit(
+        SocketEventName.JOIN_GAME,
+        input.gameId,
+        playerSetupData,
+        (err, response) => {
+          if (err) return reject(new Error(NO_ANSWER));
+          if (response.success) {
+            resolve(response);
+          } else {
+            reject(new Error(response.message || "Failed to join game."));
+          }
+        },
+      );
   });
 });
 
@@ -49,12 +63,15 @@ export const rejoinActor = fromPromise<
   { gameId: string; playerId: string; token?: string }
 >(async ({ input }) => {
   return new Promise((resolve, reject) => {
-    socket.emit(SocketEventName.ATTEMPT_REJOIN, input, (response) => {
-      if (response.success && response.gameState) {
-        resolve(response);
-      } else {
-        reject(new Error(response.message || "Failed to rejoin."));
-      }
-    });
+    socket
+      .timeout(HANDSHAKE_TIMEOUT_MS)
+      .emit(SocketEventName.ATTEMPT_REJOIN, input, (err, response) => {
+        if (err) return reject(new Error(NO_ANSWER));
+        if (response.success && response.gameState) {
+          resolve(response);
+        } else {
+          reject(new Error(response.message || "Failed to rejoin."));
+        }
+      });
   });
 });

--- a/client/machines/uiMachine.ts
+++ b/client/machines/uiMachine.ts
@@ -885,10 +885,14 @@ export const uiMachine = setup({
         INITIAL_PEEK_INFO: {
           actions: "setInitialPeekCards",
         },
-        START_GAME: { actions: "emitPlayerAction" },
-        DECLARE_LOBBY_READY: { actions: "emitPlayerAction" },
-        DECLARE_LOBBY_UNREADY: { actions: "emitPlayerAction" },
-        REMOVE_PLAYER: { actions: "emitPlayerAction" },
+        START_GAME: { actions: ["markActionPending", "emitPlayerAction"] },
+        DECLARE_LOBBY_READY: {
+          actions: ["markActionPending", "emitPlayerAction"],
+        },
+        DECLARE_LOBBY_UNREADY: {
+          actions: ["markActionPending", "emitPlayerAction"],
+        },
+        REMOVE_PLAYER: { actions: ["markActionPending", "emitPlayerAction"] },
         DRAW_FROM_DECK: { actions: ["markActionPending", "emitPlayerAction"] },
         DRAW_FROM_DISCARD: {
           actions: ["markActionPending", "emitPlayerAction"],
@@ -1173,7 +1177,17 @@ export const uiMachine = setup({
             ],
           },
         },
-        recoveryFailed: { entry: ["clearSession", "redirectToHome"] },
+        recoveryFailed: {
+          entry: [
+            "clearSession",
+            () =>
+              toast.error("Could not rejoin", {
+                description: "That game is no longer available.",
+              }),
+            // Navigate rather than reload, so the explanation survives the trip.
+            emit(() => ({ type: "NAVIGATE" as const, path: "/" })),
+          ],
+        },
         promptToJoin: {
           tags: ["prompting"],
           entry: assign({


### PR DESCRIPTION
Closes #123.

## The hang

`createGameActor`, `joinGameActor` and `rejoinActor` all passed a bare callback to `socket.emit`. On close, socket.io deletes a pending callback without calling it unless the emit was given a timeout (`socket.io-client/build/cjs/socket.js:479`, the `ack.withError` branch), so the promise behind the invoke never settled. `outOfGame` reacts to neither `CONNECT` nor `DISCONNECT`, so nothing could move the machine on afterwards either.

Measured against the real server, driving the real `uiMachine`, killing the transport between the click and the answer:

```
without the fix                                   with the fix
after the click : creatingGame  loading=true      after the click : creatingGame  loading=true
machine now     : creatingGame  loading=true      machine now     : idle          loading=false
```

The socket reconnects successfully in both runs. Only the first one is still spinning, and it stays that way until the page is reloaded.

## One detail that shaped the fix

`_registerAckCallback` starts the timer when the packet is **created**, not when it is sent. A short timeout would therefore fire during a legitimate cold start, where the emit sits in socket.io's buffer waiting for the server to wake up, which is precisely the situation this issue is about. So the timeout is deliberately generous and exists only to bound the worst case.

The fast path does not depend on it. Giving the emit a timeout also marks it to be errored the instant the socket drops, which is what actually rescues the case above.

## Also in scope, both listed in the issue

Lobby buttons acknowledge a press. `START_GAME`, `DECLARE_LOBBY_READY`, `DECLARE_LOBBY_UNREADY` and `REMOVE_PLAYER` had no pending marker, so the one place "I clicked and nothing happened" was reported most had nothing to see. This was only safe to add once #124 and #126 made an undeliverable or refused action clear the marker itself, rather than leaving the bar stuck.

A player whose rejoin is turned down is told why, and gets there by navigating rather than reloading. `redirectToHome` sets `window.location.href`, which threw away any explanation along with the page.

## A note on the measurement

The first version of this repro was wrong and passed for the wrong reason. It imported the socket as `./lib/socket.ts` while `actors.ts` imports `@/lib/socket`, and jiti treats those as two module instances, so the script was killing a socket the actor never used. The tell was there and I missed it at first: the server never logged "Creating game" for a click that supposedly reached it.

It now asserts a pending ack on the very socket instance it goes on to kill, so a repeat of that mistake fails loudly instead of quietly agreeing with me.

`npm run verify` passes end to end.
