### PR TITLE
Tell the site its own address, and keep crawlers out of rooms

### DIFF
--- a/client/app/layout.tsx
+++ b/client/app/layout.tsx
@@ -2,6 +2,7 @@ import "./globals.css";
 import type { Metadata } from "next";
 import { Nunito_Sans } from "next/font/google";
 import { Providers } from "./providers";
+import { SITE_URL } from "@/lib/site";
 import "lenis/dist/lenis.css";
 
 // The one type family, app-wide (exposed as --font-game). The landing page
@@ -12,12 +13,17 @@ const nunito = Nunito_Sans({
 });
 
 export const metadata: Metadata = {
+  // Every relative URL below, and the generated opengraph-image, resolves
+  // against this. Without it Next falls back to VERCEL_URL or localhost, so
+  // the share card points somewhere nobody can reach.
+  metadataBase: new URL(SITE_URL),
   title: "Check! - The Card Game",
   description: "A card game of strategy, memory, and luck.",
+  alternates: { canonical: "/" },
   openGraph: {
     title: "Check!",
     description: "Play online with friends, in real time.",
-    url: "https://check-the-game.vercel.app",
+    url: "/",
     type: "website",
   },
   twitter: {

--- a/client/app/robots.ts
+++ b/client/app/robots.ts
@@ -1,0 +1,17 @@
+import type { MetadataRoute } from "next";
+import { SITE_URL } from "@/lib/site";
+
+// A lobby code is five characters and /game/<code> renders for anyone who
+// opens it, so an indexed room URL is a stranger walking into a live game.
+// Rooms are short lived, which is why this is a crawler instruction rather
+// than an access control; guessing codes outright is tracked in #130.
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: "/game/",
+    },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+  };
+}

--- a/client/app/rules/page.tsx
+++ b/client/app/rules/page.tsx
@@ -5,11 +5,12 @@ export const metadata: Metadata = {
   title: "Rules · Check!",
   description:
     "The complete rules of Check!: card values, setup, turns, the matching window, King, Queen and Jack abilities, calling Check, and scoring.",
+  alternates: { canonical: "/rules" },
   openGraph: {
     title: "Rules · Check!",
     description:
       "Learn Check! in five minutes, then call it at the perfect moment.",
-    url: "https://check-the-game.vercel.app/rules",
+    url: "/rules",
     type: "article",
   },
 };

--- a/client/app/sitemap.ts
+++ b/client/app/sitemap.ts
@@ -1,0 +1,11 @@
+import type { MetadataRoute } from "next";
+import { SITE_URL } from "@/lib/site";
+
+// The landing page and the rules are the only public routes. /game/<code> is
+// a live room rather than a page, and robots.ts tells crawlers to skip it.
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    { url: `${SITE_URL}/`, changeFrequency: "monthly", priority: 1 },
+    { url: `${SITE_URL}/rules`, changeFrequency: "monthly", priority: 0.8 },
+  ];
+}

--- a/client/lib/site.ts
+++ b/client/lib/site.ts
@@ -1,0 +1,9 @@
+// The canonical origin, in one place because three files need it absolute:
+// the root metadataBase, the sitemap's entries and the robots sitemap line.
+//
+// Deliberately not read from the environment. A preview deployment should
+// still declare production as canonical, and Next's fallback chain is what
+// this exists to escape: with no metadataBase it resolves social images
+// against VERCEL_URL, the per-deployment hostname, or localhost in a local
+// build. Neither is a URL anyone shares.
+export const SITE_URL = "https://check-the-game.vercel.app";


### PR DESCRIPTION
Fixes #146

## What this changes

`metadataBase` on the root metadata export, so every relative URL and the
generated `opengraph-image` resolve against the canonical origin. Without it
Next fell back to `VERCEL_URL` or localhost, which is why link previews were
broken on every deploy.

The canonical origin now lives in `client/lib/site.ts` rather than being typed
out in both `layout.tsx` and `rules/page.tsx`. Both pages also declare a
canonical URL.

Adds `client/app/robots.ts` and `client/app/sitemap.ts`. The two public routes
are declared, and `/game/` is disallowed: a room URL renders the join prompt,
and a lobby that has not started yet will let a stranger straight in.

## What I ran

`npm run verify` passes.

The metadataBase build warning is gone, and both routes generate:

```
├ ○ /robots.txt      134 B
└ ○ /sitemap.xml     134 B
```

`robots.txt`:

```
User-Agent: *
Allow: /
Disallow: /game/

Sitemap: https://check-the-game.vercel.app/sitemap.xml
```

`sitemap.xml` carries `/` and `/rules` and nothing else.

The share card now resolves against the real host in the built HTML, which is
the actual bug this fixes:

```html
<link rel="canonical" href="https://check-the-game.vercel.app"/>
<meta property="og:image" content="https://check-the-game.vercel.app/opengraph-image?0b0659408ecfb4c1"/>
```

`/rules` checks out the same way, canonical and `og:url` both
`https://check-the-game.vercel.app/rules`.

## Left for the preview

The issue's done-when includes both routes resolving on a real deployment,
which only a deploy proves. Everything checkable locally is checked.

## A judgement call worth a look

`SITE_URL` is hardcoded rather than read from the environment. A canonical URL
should not vary by deployment, and a preview should still point at production
as canonical, so making it configurable seemed like an invitation to set it
wrong. Reasoning is in the file's comment. Easy to change if you disagree.