### PR TITLE
Verify the site with Google Search Console

### DIFF
--- a/client/app/layout.tsx
+++ b/client/app/layout.tsx
@@ -19,6 +19,10 @@ export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
   title: "Check! - The Card Game",
   description: "A card game of strategy, memory, and luck.",
+  // Proves ownership of the Search Console property. A public tag rather than
+  // a secret, and it has to stay: Google re-checks, so a property that loses
+  // its tag goes unverified again.
+  verification: { google: "w0uP0kvKNvORgtpbYZQ8UDucoJr4CDUfi0XLACdzaR0" },
   alternates: { canonical: "/" },
   openGraph: {
     title: "Check!",


### PR DESCRIPTION
Fixes #151

Adds the Search Console verification tag to the root metadata export.

```html
<meta name="google-site-verification" content="w0uP0kvKNvORgtpbYZQ8UDucoJr4CDUfi0XLACdzaR0"/>
```

The HTML tag is the only method available here. DNS verification needs control
of the `vercel.app` zone, which is Vercel's, and there is no Analytics or Tag
Manager in the project. If the site ever moves to a custom domain, DNS becomes
available and is more robust, since it survives a deploy that drops the tag.

The tag is public, appearing in the head of every page a visitor loads, so it
sits in the source next to the rest of the metadata rather than in an
environment variable. The comment says as much, and says it must not be removed
after verifying, because Google re-checks and an untagged property goes
unverified again.

## What I ran

`npm run verify` passes. The tag renders on both public routes:

```
client/.next/server/app/index.html:<meta name="google-site-verification" content="w0uP..."/>
client/.next/server/app/rules.html:<meta name="google-site-verification" content="w0uP..."/>
```

## Still to do after this deploys, in order

These are the account-side steps from #151 and cannot be done from a branch:

1. Click Verify in Search Console, once production is serving the tag
2. Submit `https://check-the-game.vercel.app/sitemap.xml`
3. Request indexing for `/` and `/rules`

Verifying before the deploy is live will fail, so the order matters.