### PR TITLE
Tell the client whose seat was taken by another window

### DIFF
--- a/client/app/providers.tsx
+++ b/client/app/providers.tsx
@@ -86,6 +86,7 @@ function UIMachineEffects({ actor }: { actor: UIMachineActorRef }) {
       actor.send({ type: "ABILITY_PEEK_RESULT", results: d.results });
     const er = (e: { message: string }) =>
       actor.send({ type: "ERROR_RECEIVED", error: e.message });
+    const sce = () => actor.send({ type: "SEAT_CLAIMED_ELSEWHERE" });
     const ce = (err: Error) =>
       logger.warn(
         { error: err?.message ?? "connection error" },
@@ -120,6 +121,7 @@ function UIMachineEffects({ actor }: { actor: UIMachineActorRef }) {
     socket.on(SocketEventName.INITIAL_PEEK_INFO, pk);
     socket.on(SocketEventName.ABILITY_PEEK_RESULT, pr);
     socket.on(SocketEventName.ERROR_MESSAGE, er);
+    socket.on(SocketEventName.SEAT_CLAIMED_ELSEWHERE, sce);
     socket.on(SocketEventName.INITIAL_LOGS, il);
     socket.on("connect", onConnect);
     socket.on("connect_error", ce);
@@ -147,6 +149,7 @@ function UIMachineEffects({ actor }: { actor: UIMachineActorRef }) {
       socket.off(SocketEventName.INITIAL_PEEK_INFO, pk);
       socket.off(SocketEventName.ABILITY_PEEK_RESULT, pr);
       socket.off(SocketEventName.ERROR_MESSAGE, er);
+      socket.off(SocketEventName.SEAT_CLAIMED_ELSEWHERE, sce);
       socket.off(SocketEventName.INITIAL_LOGS, il);
       socket.off("connect", onConnect);
       socket.off("connect_error", ce);

--- a/client/components/game/GameUI.tsx
+++ b/client/components/game/GameUI.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import React from "react";
-import { useUISelector, type UIMachineSnapshot } from "@/context/GameUIContext";
+import {
+  useUISelector,
+  useUIActorRef,
+  type UIMachineSnapshot,
+} from "@/context/GameUIContext";
 import { GameBoard } from "@/components/game/GameBoard";
 import { GameLobby } from "@/components/game/GameLobby";
 import LoadingOrError from "@/components/layout/LoadingOrError";
@@ -11,9 +15,13 @@ import CardAnimationRoot from "@/components/cards/CardAnimationRoot";
 import { GameStage } from "shared-types";
 import { useGameSounds } from "@/components/game/useGameSounds";
 
-type GameView = "prompting" | "lobby" | "game" | "connecting";
+type GameView = "superseded" | "prompting" | "lobby" | "game" | "connecting";
 
 const selectView = (s: UIMachineSnapshot): GameView => {
+  // Checked before everything else: the board underneath is whatever arrived
+  // last and will never update again, so showing it would be the silent freeze
+  // this state exists to replace.
+  if (s.matches({ inGame: "seatClaimedElsewhere" })) return "superseded";
   if (
     s.context.modal?.type === "rejoin" ||
     s.matches({ inGame: "promptToJoin" })
@@ -26,6 +34,39 @@ const selectView = (s: UIMachineSnapshot): GameView => {
   return "connecting";
 };
 
+// Shown to the client that just lost the seat to another window. The takeover
+// itself is legitimate and expected once the game is installable, so this
+// explains rather than apologises, and offers the way back that the machine
+// used to take on its own after eight silent seconds.
+const SupersededNotice = () => {
+  const { send } = useUIActorRef();
+  return (
+    <div className="flex h-full w-full items-center justify-center p-4">
+      <div className="flex max-w-sm flex-col items-center gap-4 rounded-2xl border border-hairline bg-surface p-8 text-center">
+        <h3 className="text-2xl font-extrabold text-ink">
+          You opened this game somewhere else
+        </h3>
+        <p className="text-sm text-ink-muted">
+          Your seat moved to the window you opened most recently, so this one
+          has stopped following the game. You can bring it back here.
+        </p>
+        <button
+          onClick={() => send({ type: "RETRY_REJOIN" })}
+          className="rounded-full bg-accent px-6 py-2.5 text-sm font-bold text-accent-ink hover:bg-accent/90"
+        >
+          Play here instead
+        </button>
+        <button
+          onClick={() => send({ type: "LEAVE_GAME" })}
+          className="text-xs font-semibold text-ink-muted underline underline-offset-4 hover:text-ink"
+        >
+          Back to Home
+        </button>
+      </div>
+    </div>
+  );
+};
+
 export default function GameUI() {
   const view = useUISelector(selectView);
   // Mounted here so the table's voice covers the lobby (joins, readies,
@@ -34,6 +75,8 @@ export default function GameUI() {
 
   const renderContent = () => {
     switch (view) {
+      case "superseded":
+        return <SupersededNotice />;
       case "prompting":
         return <LoadingOrError message="Awaiting your input..." />;
       case "lobby":

--- a/client/machines/uiMachine.ts
+++ b/client/machines/uiMachine.ts
@@ -112,6 +112,7 @@ export type UIMachineEvents =
     }
   | { type: "ACTION_NOT_SENT" }
   | { type: "ACTION_UNANSWERED" }
+  | { type: "SEAT_CLAIMED_ELSEWHERE" }
   | { type: "CONFIRM_ABILITY_ACTION" }
   | { type: "SKIP_ABILITY_STAGE" }
   | { type: "TOGGLE_SIDE_PANEL" }
@@ -948,6 +949,11 @@ export const uiMachine = setup({
         // Reachable from every game view, not just the lobby, so a player who
         // can see something is wrong is never told to reload the page.
         RETRY_REJOIN: { target: ".reconnecting" },
+        // The server only sends this to a socket that is still open, so it
+        // always means a second client took the seat rather than a reconnect
+        // after a drop. Handled here rather than per state because it can
+        // arrive during any of them.
+        SEAT_CLAIMED_ELSEWHERE: { target: ".seatClaimedElsewhere" },
       },
       states: {
         routing: {
@@ -1185,6 +1191,22 @@ export const uiMachine = setup({
               },
               { target: "disconnected" },
             ],
+          },
+        },
+        // Another client holds the seat. Deliberately terminal: the watchdog
+        // below would otherwise re-run the handshake eight seconds after the
+        // last unanswered action and take the seat back with nobody asking,
+        // which is how two windows end up trading it. Nulling
+        // pendingActionSince is what disarms it, since ACTION_UNANSWERED is
+        // guarded on that field rather than cancelled by id.
+        //
+        // The session is kept, not cleared: RETRY_REJOIN needs the token, and
+        // taking the seat back is a decision for the player rather than a
+        // timer.
+        seatClaimedElsewhere: {
+          entry: assign({ pendingActionSince: null }),
+          on: {
+            RETRY_REJOIN: { target: "reconnecting" },
           },
         },
         recoveryFailed: {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -190,7 +190,21 @@ io.on("connection", (socket: Socket) => {
   const registerSocketSession = (gameId: GameId, playerId: PlayerId) => {
     // Remove any previous socketId mapped to this player
     for (const [sid, sess] of socketSessionMap.entries()) {
-      if (sess.playerId === playerId) socketSessionMap.delete(sid);
+      if (sess.playerId !== playerId) continue;
+      // A previous socket that is still open is a second client taking the
+      // seat, not a reconnect after a dropped one. Only the first case has
+      // anyone left to tell, and telling them is the whole fix: the takeover
+      // is legitimate, the silence afterwards is not. Sent before the entry
+      // goes, because after it this socket is unreachable through the session
+      // map and its actions are dropped with no reply.
+      if (sid !== socket.id && io.sockets.sockets.has(sid)) {
+        logger.info(
+          { gameId, playerId, supersededSocketId: sid, bySocketId: socket.id },
+          "Seat claimed by another client; telling the one it replaces",
+        );
+        io.to(sid).emit(SocketEventName.SEAT_CLAIMED_ELSEWHERE);
+      }
+      socketSessionMap.delete(sid);
     }
     socketSessionMap.set(socket.id, { gameId, playerId });
   };

--- a/shared-types/src/index.ts
+++ b/shared-types/src/index.ts
@@ -231,6 +231,7 @@ export interface ServerToClientEvents {
   [SocketEventName.INITIAL_LOGS]: (logs: RichGameLogMessage[]) => void;
   [SocketEventName.ERROR_MESSAGE]: (error: { message: string }) => void;
   [SocketEventName.NEW_CHAT_MESSAGE]: (chatMessage: ChatMessage) => void;
+  [SocketEventName.SEAT_CLAIMED_ELSEWHERE]: () => void;
 }
 
 export interface ClientToServerEvents {
@@ -274,6 +275,10 @@ export enum SocketEventName {
   SERVER_LOG_ENTRY = "SERVER_LOG_ENTRY",
   INITIAL_LOGS = "INITIAL_LOGS",
   NEW_CHAT_MESSAGE = "NEW_CHAT_MESSAGE",
+  /** Sent to a client whose seat has just been claimed by another one, so it
+   *  can say so instead of freezing. Only ever reaches a socket that is still
+   *  open, which is what separates a takeover from an ordinary reconnect. */
+  SEAT_CLAIMED_ELSEWHERE = "SEAT_CLAIMED_ELSEWHERE",
 }
 
 export interface BasicResponse {


### PR DESCRIPTION
Fixes #129

## What was wrong

Opening the same game in a second window moved the seat to the newer client and
left the older one silently dead. Traced end to end with two `socket.io-client`
connections against a running server:

```
A created 486US   token issued: true
B rejoin accepted: true

-- after the takeover --
A socket still connected  : true    | disconnect reason: null
A told anything at all    : NOTHING
A gets further state      : false (1 -> 1)
B gets state              : true
A's action changed anything: false
A still receives chat      : true (1 messages)
```

Two things beyond the issue's description, both recorded there:

**It was a loop, not a freeze.** `markActionPending` raises `ACTION_UNANSWERED`
on an eight second delay, which targets `.reconnecting`, which re-runs
`ATTEMPT_REJOIN`. So pressing any button in the dead window silently killed the
live one eight seconds later, and the pair could trade the seat indefinitely.

**The dead window still received chat.** `socket.leave` runs only on an explicit
`LEAVE_GAME`, and chat is the one room-wide broadcast while game state is
targeted per socket. So it did not read as broken.

## What this changes

`registerSocketSession` is the only place a live socket is evicted, because
`CREATE_GAME` and `JOIN_GAME` both mint a fresh player id and cannot match an
existing entry. It now tells that socket before dropping it, guarded on
`io.sockets.sockets.has(sid)`, which is what separates a second client taking
the seat from an ordinary reconnect after a dropped link. The same check already
exists a few lines above, where `broadcastGameState` logs the condition.

The client gets a terminal state rather than a toast, since a toast over a board
that will never update again is still a dead board. Its entry nulls
`pendingActionSince`, which disarms the watchdog above. Without that, the screen
saying the seat had moved would take it straight back on its own. Taking it back
is now a button, using the `RETRY_REJOIN` event that already existed.

## What I ran

`npm run verify` passes. Behaviour checked against a running server, in both
directions, because the false-positive case is the one that matters:

```
CASE 1: second client takes the seat while the first is live
  superseded client told : true   <- FIXED
  its socket still open  : true   | disconnect: null

CASE 2: ordinary reconnect after the first socket is gone
  rejoin accepted        : true
  anyone wrongly told    : false  <- correct, stayed silent
```

## This one cannot be checked on the preview

It touches `shared-types`, so the preview client talks to a production server
that does not know the new event, which per CONTRIBUTING looks exactly like a
client bug. Local against both halves is the only way to see it work.

The new event degrades safely in the deploy window #132 describes: an older
client does not listen for it and behaves as it does today.

## Left alone deliberately

The evicted socket stays in the room, so chat keeps arriving. Once the window
says what happened that is context rather than confusion, and changing room
membership would be a second behaviour change in one fix. Noted on the issue.