### PR TITLE
Make the game installable to a home screen

### DIFF
--- a/client/app/apple-icon.tsx
+++ b/client/app/apple-icon.tsx
@@ -1,0 +1,54 @@
+import { ImageResponse } from "next/og";
+
+// iOS does not read the manifest for the home screen icon, it wants an
+// apple-touch-icon, and it does not round or pad one either. So this is the
+// mark on the app's own ground at the size Apple asks for, drawn from the same
+// tokens as opengraph-image.tsx.
+export const size = { width: 180, height: 180 };
+export const contentType = "image/png";
+
+const GROUND = "#121212"; // --ground   0 0% 7%
+const ACCENT = "#BA3F3B"; // --accent   2 52% 48%
+const ACCENT_INK = "#FFF6F0"; // --accent-ink 23 100% 97%
+
+export default function AppleIcon() {
+  return new ImageResponse(
+    <div
+      style={{
+        width: size.width,
+        height: size.height,
+        background: GROUND,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      <div
+        style={{
+          width: 96,
+          height: 134,
+          borderRadius: 18,
+          background: ACCENT,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          transform: "rotate(-6deg)",
+        }}
+      >
+        <svg
+          width={60}
+          height={60}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke={ACCENT_INK}
+          strokeWidth={3}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M20 6 9 17l-5-5" />
+        </svg>
+      </div>
+    </div>,
+    size,
+  );
+}

--- a/client/app/icon-512/route.tsx
+++ b/client/app/icon-512/route.tsx
@@ -1,0 +1,56 @@
+import { ImageResponse } from "next/og";
+
+// The raster icon at purpose "any", alongside the SVG favicon. Installability
+// checks look for a raster icon of at least 192 that is not maskable-only, and
+// a maskable drawing cannot double as this one: it carries padding for a crop
+// that will not happen here, so unmasked it reads as a small mark adrift in a
+// large square.
+export const dynamic = "force-static";
+
+const GROUND = "#121212"; // --ground     0 0% 7%
+const ACCENT = "#BA3F3B"; // --accent     2 52% 48%
+const ACCENT_INK = "#FFF6F0"; // --accent-ink 23 100% 97%
+
+const SIZE = 512;
+
+export function GET() {
+  return new ImageResponse(
+    <div
+      style={{
+        width: SIZE,
+        height: SIZE,
+        background: GROUND,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      <div
+        style={{
+          width: 280,
+          height: 392,
+          borderRadius: 48,
+          background: ACCENT,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          transform: "rotate(-6deg)",
+        }}
+      >
+        <svg
+          width={172}
+          height={172}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke={ACCENT_INK}
+          strokeWidth={3}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M20 6 9 17l-5-5" />
+        </svg>
+      </div>
+    </div>,
+    { width: SIZE, height: SIZE },
+  );
+}

--- a/client/app/layout.tsx
+++ b/client/app/layout.tsx
@@ -1,5 +1,5 @@
 import "./globals.css";
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Nunito_Sans } from "next/font/google";
 import { Providers } from "./providers";
 import { SITE_URL } from "@/lib/site";
@@ -33,6 +33,15 @@ export const metadata: Metadata = {
   twitter: {
     card: "summary_large_image",
   },
+};
+
+// themeColor tints the OS chrome around an installed window and the browser
+// UI on mobile. Static and dark rather than a prefers-color-scheme pair,
+// because providers.tsx sets defaultTheme="dark": a visitor whose system is
+// light still sees the dark app unless they change it, so a light tint would
+// frame a dark board.
+export const viewport: Viewport = {
+  themeColor: "#121212",
 };
 
 export default function RootLayout({

--- a/client/app/manifest.ts
+++ b/client/app/manifest.ts
@@ -1,0 +1,30 @@
+import type { MetadataRoute } from "next";
+
+// Dark, resolved to hex because a manifest cannot read CSS variables. Same
+// reasoning and same values as opengraph-image.tsx: dark is the app's default
+// theme (providers.tsx sets defaultTheme="dark"), so the splash and the window
+// chrome match what a visitor actually sees rather than the light palette.
+const GROUND = "#121212"; // --ground 0 0% 7%
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: "Check! - The Card Game",
+    short_name: "Check!",
+    description: "A card game of strategy, memory, and luck.",
+    start_url: "/",
+    display: "standalone",
+    background_color: GROUND,
+    theme_color: GROUND,
+    orientation: "any",
+    icons: [
+      { src: "/icon.svg", type: "image/svg+xml", sizes: "any" },
+      { src: "/icon-512", type: "image/png", sizes: "512x512", purpose: "any" },
+      {
+        src: "/maskable-icon",
+        type: "image/png",
+        sizes: "512x512",
+        purpose: "maskable",
+      },
+    ],
+  };
+}

--- a/client/app/maskable-icon/route.tsx
+++ b/client/app/maskable-icon/route.tsx
@@ -1,0 +1,59 @@
+import { ImageResponse } from "next/og";
+
+// A maskable icon is cropped to whatever shape the platform likes, so the mark
+// has to survive a circle cut out of the middle 80%. The favicon at
+// app/icon.svg fills its own box and would lose its corners here, which is why
+// this is a separate drawing rather than the same file at another size.
+// Route handlers are dynamic by default, and an icon rendered per request is
+// pure waste: this drawing never changes. Prerender it with the rest.
+export const dynamic = "force-static";
+
+const GROUND = "#121212"; // --ground   0 0% 7%
+const ACCENT = "#BA3F3B"; // --accent   2 52% 48%
+const ACCENT_INK = "#FFF6F0"; // --accent-ink 23 100% 97%
+
+const SIZE = 512;
+
+export function GET() {
+  return new ImageResponse(
+    <div
+      style={{
+        width: SIZE,
+        height: SIZE,
+        background: GROUND,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      {/* Inside the safe zone: 5:7 card, the app's own proportion, sized so
+            its rotated corners stay clear of a circular crop. */}
+      <div
+        style={{
+          width: 200,
+          height: 280,
+          borderRadius: 34,
+          background: ACCENT,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          transform: "rotate(-6deg)",
+        }}
+      >
+        <svg
+          width={124}
+          height={124}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke={ACCENT_INK}
+          strokeWidth={3}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M20 6 9 17l-5-5" />
+        </svg>
+      </div>
+    </div>,
+    { width: SIZE, height: SIZE },
+  );
+}


### PR DESCRIPTION
Fixes #147

## What this adds

`client/app/manifest.ts`, a `viewport` export carrying `themeColor`, and the
icon sizes the platforms ask for. The emitted manifest:

```json
{
  "name": "Check! - The Card Game",
  "short_name": "Check!",
  "start_url": "/",
  "display": "standalone",
  "background_color": "#121212",
  "theme_color": "#121212",
  "icons": [
    { "src": "/icon.svg",       "type": "image/svg+xml", "sizes": "any" },
    { "src": "/icon-512",       "type": "image/png", "sizes": "512x512", "purpose": "any" },
    { "src": "/maskable-icon",  "type": "image/png", "sizes": "512x512", "purpose": "maskable" }
  ]
}
```

and the head now carries `theme-color`, `rel="manifest"` and
`rel="apple-touch-icon"` alongside the existing SVG icon.

## Why three icons

They are the same mark at different crops, which is the whole reason they cannot
be one file resized:

- `icon-512` (`any`) fills its frame, never cropped.
- `maskable-icon` is deliberately smaller. A platform mask cuts a circle out of
  the middle 80%, and at 200x280 rotated the card's corners land 172px from
  centre against a 205px safe radius.
- `apple-icon` fills again. iOS ignores the manifest for home screen icons and
  applies its own mask with no padding.

All three are generated with `ImageResponse` from the same hex constants
`opengraph-image.tsx` already resolved from the dark tokens, rather than checked
in as PNGs.

## Two things worth a look in review

`/maskable-icon` and `/icon-512` are route handlers, which are dynamic by
default. Both carry `export const dynamic = "force-static"`, otherwise a fixed
drawing would be re-rendered on every request. The build confirms all three
generated images are `○ Static`.

The only `purpose: "any"` icon was originally the SVG. Installability checks
look for a raster icon of at least 192 that is not maskable-only, so `/icon-512`
exists rather than gambling on SVG support.

## What I ran

`npm run verify` passes. Each generated image checked as a real PNG at the right
dimensions (`apple-icon` 180x180, the other two 512x512) and rendered to look at.

## What only a real device can answer

Listed because none of it is checkable from a branch:

1. **Whether it installs.** The criteria are met as I understand them, but the
   bar has moved before, which the issue already says to check rather than
   assume.
2. **Whether a service worker turns out to be required.** None added: the issue
   is explicit that nothing should be cached, since a cached shell opens to a
   board it cannot populate.
3. **The vertical space gain.** The probe drives a fixed viewport and cannot
   simulate the absence of browser chrome.
4. **The second-window case.** #129 is fixed and merged, so an installed window
   opening alongside a browser tab should say so rather than freeze. That
   pairing is what motivated fixing it, and this is the first chance to see it.