### PR TITLE
Say what the game is in the title and description

### DIFF
--- a/client/app/game/layout.tsx
+++ b/client/app/game/layout.tsx
@@ -1,4 +1,11 @@
+import type { Metadata } from "next";
 import React from "react";
+
+// A room sets no title of its own, so without this it inherits the root's
+// search sentence and a tab mid-game reads the landing page's ad copy.
+export const metadata: Metadata = {
+  title: "Check!",
+};
 
 export default function GameLayout({
   children,

--- a/client/app/layout.tsx
+++ b/client/app/layout.tsx
@@ -2,7 +2,7 @@ import "./globals.css";
 import type { Metadata, Viewport } from "next";
 import { Nunito_Sans } from "next/font/google";
 import { Providers } from "./providers";
-import { SITE_URL } from "@/lib/site";
+import { SITE_DESCRIPTION, SITE_URL } from "@/lib/site";
 import "lenis/dist/lenis.css";
 
 // The one type family, app-wide (exposed as --font-game). The landing page
@@ -17,8 +17,13 @@ export const metadata: Metadata = {
   // against this. Without it Next falls back to VERCEL_URL or localhost, so
   // the share card points somewhere nobody can reach.
   metadataBase: new URL(SITE_URL),
-  title: "Check! - The Card Game",
-  description: "A card game of strategy, memory, and luck.",
+  // Read far beyond a search result: the title is the browser tab, the
+  // bookmark, the history entry, and the fallback when the link is pasted
+  // somewhere that does not read the OG tags below. So both of these describe
+  // the game rather than name it, and both are sized to what actually gets
+  // printed, roughly 60 characters of title and 155 of description.
+  title: "Check! - free online card game to play with friends",
+  description: SITE_DESCRIPTION,
   // Proves ownership of the Search Console property. A public tag rather than
   // a secret, and it has to stay: Google re-checks, so a property that loses
   // its tag goes unverified again.
@@ -44,6 +49,28 @@ export const viewport: Viewport = {
   themeColor: "#121212",
 };
 
+// Structured data, so a crawler is told what this page is rather than left to
+// work it out from the prose. VideoGame is the type that carries the things
+// worth stating about a browser game: that it is multiplayer, that it seats two
+// to six, and that it costs nothing. Written out as a script tag because Next
+// has no metadata field for JSON-LD.
+const gameSchema = {
+  "@context": "https://schema.org",
+  "@type": "VideoGame",
+  name: "Check!",
+  url: SITE_URL,
+  description: SITE_DESCRIPTION,
+  genre: "Card game",
+  gamePlatform: "Web browser",
+  applicationCategory: "GameApplication",
+  operatingSystem: "Any",
+  playMode: "MultiPlayer",
+  numberOfPlayers: { "@type": "QuantitativeValue", minValue: 2, maxValue: 6 },
+  offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
+  isAccessibleForFree: true,
+  inLanguage: "en",
+};
+
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -52,6 +79,10 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning className={nunito.variable}>
       <body className="font-game antialiased">
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(gameSchema) }}
+        />
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/client/app/layout.tsx
+++ b/client/app/layout.tsx
@@ -17,11 +17,8 @@ export const metadata: Metadata = {
   // against this. Without it Next falls back to VERCEL_URL or localhost, so
   // the share card points somewhere nobody can reach.
   metadataBase: new URL(SITE_URL),
-  // Read far beyond a search result: the title is the browser tab, the
-  // bookmark, the history entry, and the fallback when the link is pasted
-  // somewhere that does not read the OG tags below. So both of these describe
-  // the game rather than name it, and both are sized to what actually gets
-  // printed, roughly 60 characters of title and 155 of description.
+  // Inherited by any route that sets no title of its own, which is why
+  // app/game/layout.tsx sets one: a room tab must not read this sentence.
   title: "Check! - free online card game to play with friends",
   description: SITE_DESCRIPTION,
   // Proves ownership of the Search Console property. A public tag rather than
@@ -49,16 +46,13 @@ export const viewport: Viewport = {
   themeColor: "#121212",
 };
 
-// Structured data, so a crawler is told what this page is rather than left to
-// work it out from the prose. VideoGame is the type that carries the things
-// worth stating about a browser game: that it is multiplayer, that it seats two
-// to six, and that it costs nothing. Written out as a script tag because Next
-// has no metadata field for JSON-LD.
+// A script tag because Next has no metadata field for JSON-LD.
 const gameSchema = {
   "@context": "https://schema.org",
   "@type": "VideoGame",
   name: "Check!",
-  url: SITE_URL,
+  // Trailing slash, so this agrees with the canonical and the sitemap entry.
+  url: `${SITE_URL}/`,
   description: SITE_DESCRIPTION,
   genre: "Card game",
   gamePlatform: "Web browser",
@@ -71,6 +65,10 @@ const gameSchema = {
   inLanguage: "en",
 };
 
+// Escaped and serialised once. A raw "<" in any field, most plausibly a future
+// edit to SITE_DESCRIPTION, would close the script element early.
+const gameSchemaJson = JSON.stringify(gameSchema).replace(/</g, "\\u003c");
+
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -81,7 +79,7 @@ export default function RootLayout({
       <body className="font-game antialiased">
         <script
           type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(gameSchema) }}
+          dangerouslySetInnerHTML={{ __html: gameSchemaJson }}
         />
         <Providers>{children}</Providers>
       </body>

--- a/client/app/manifest.ts
+++ b/client/app/manifest.ts
@@ -1,4 +1,5 @@
 import type { MetadataRoute } from "next";
+import { SITE_DESCRIPTION } from "@/lib/site";
 
 // Dark, resolved to hex because a manifest cannot read CSS variables. Same
 // reasoning and same values as opengraph-image.tsx: dark is the app's default
@@ -10,7 +11,7 @@ export default function manifest(): MetadataRoute.Manifest {
   return {
     name: "Check! - The Card Game",
     short_name: "Check!",
-    description: "A card game of strategy, memory, and luck.",
+    description: SITE_DESCRIPTION,
     start_url: "/",
     display: "standalone",
     background_color: GROUND,

--- a/client/app/rules/page.tsx
+++ b/client/app/rules/page.tsx
@@ -2,7 +2,11 @@ import type { Metadata } from "next";
 import RulesContent from "./RulesContent";
 
 export const metadata: Metadata = {
-  title: "Rules · Check!",
+  // "How to play" rather than "Rules", because that is how the question gets
+  // asked. This is much the longer of the two public pages, so it is the one
+  // worth titling for what someone is actually looking for. The OG title below
+  // stays short: a share card wants the label, not the sentence.
+  title: "How to play Check! - full rules and scoring",
   description:
     "The complete rules of Check!: card values, setup, turns, the matching window, King, Queen and Jack abilities, calling Check, and scoring.",
   alternates: { canonical: "/rules" },

--- a/client/app/rules/page.tsx
+++ b/client/app/rules/page.tsx
@@ -2,10 +2,6 @@ import type { Metadata } from "next";
 import RulesContent from "./RulesContent";
 
 export const metadata: Metadata = {
-  // "How to play" rather than "Rules", because that is how the question gets
-  // asked. This is much the longer of the two public pages, so it is the one
-  // worth titling for what someone is actually looking for. The OG title below
-  // stays short: a share card wants the label, not the sentence.
   title: "How to play Check! - full rules and scoring",
   description:
     "The complete rules of Check!: card values, setup, turns, the matching window, King, Queen and Jack abilities, calling Check, and scoring.",

--- a/client/lib/site.ts
+++ b/client/lib/site.ts
@@ -7,3 +7,12 @@
 // against VERCEL_URL, the per-deployment hostname, or localhost in a local
 // build. Neither is a URL anyone shares.
 export const SITE_URL = "https://check-the-game.vercel.app";
+
+// The one sentence that says what the game is, here for the same reason as the
+// origin above: three things read it, and they have to agree. The root
+// description, the JSON-LD block beside it, and the manifest that the install
+// prompt shows. Written out separately in each, the manifest is the one that
+// quietly falls behind, because nothing about the site looks wrong when it
+// does. Sized to the roughly 155 characters a search result prints.
+export const SITE_DESCRIPTION =
+  "Deal four cards, peek at two, play for the lowest hand. A free browser card game for 2 to 6 players. Create a lobby, send the link, no account needed.";

--- a/client/lib/site.ts
+++ b/client/lib/site.ts
@@ -8,11 +8,8 @@
 // build. Neither is a URL anyone shares.
 export const SITE_URL = "https://check-the-game.vercel.app";
 
-// The one sentence that says what the game is, here for the same reason as the
-// origin above: three things read it, and they have to agree. The root
-// description, the JSON-LD block beside it, and the manifest that the install
-// prompt shows. Written out separately in each, the manifest is the one that
-// quietly falls behind, because nothing about the site looks wrong when it
-// does. Sized to the roughly 155 characters a search result prints.
+// Read by the root description, the JSON-LD beside it and the manifest. Kept in
+// one place because the manifest is the copy that quietly falls behind when it
+// is not, and nothing about the site looks wrong when that happens.
 export const SITE_DESCRIPTION =
-  "Deal four cards, peek at two, play for the lowest hand. A free browser card game for 2 to 6 players. Create a lobby, send the link, no account needed.";
+  "Check is a free online card game for 2–6 players. You are dealt four cards but only get to see two, and the lowest hand wins the round.";


### PR DESCRIPTION
Closes #156.

The title said `Check! - The Card Game` and the description said `A card game of
strategy, memory, and luck.` Neither line said what this game is. Both now do,
and both are sized to what actually gets printed.

| | before | after | length |
|---|---|---|---|
| `/` title | `Check! - The Card Game` | `Check! - free online card game to play with friends` | 51 |
| `/` description | `A card game of strategy, memory, and luck.` | `Deal four cards, peek at two, play for the lowest hand. A free browser card game for 2 to 6 players. Create a lobby, send the link, no account needed.` | 150 |
| `/rules` title | `Rules · Check!` | `How to play Check! - full rules and scoring` | 43 |

`/rules` is 1215 words against 251 on the landing page, so it is the stronger of
the two public pages and the one worth titling for how the question actually gets
asked.

## The sentence moved to `lib/site.ts`

Beside `SITE_URL`, and for the same reason the origin is there: three things read
it and they have to agree. The root description, the new JSON-LD block, and the
manifest that the install prompt shows. Written out separately in each, the
manifest is the one that quietly falls behind, because nothing about the site
looks wrong when it does. It was already carrying its own copy of the old line.

## Structured data

The client had none. A `VideoGame` block now tells a crawler the game is
multiplayer, seats two to six and costs nothing, rather than leaving it to be
inferred from prose.

## Deliberately not in this change

- **The OG and Twitter tags are untouched.** `og:title` is still `Check!` and
  `og:description` is still `Play online with friends, in real time.` A share
  card wants punch where a search snippet wants information, so making them
  match would make the card worse.
- **`manifest.name` and `short_name` are untouched.** Those are the installed
  app's name on a home screen, where the long form would read badly.
- **No `keywords` meta.** Google stopped reading it in 2009.
- **The hero `h1` is untouched.**
- **No rebrand.** The game belongs to the Cambio and Cabo family, and this
  deliberately does not say so anywhere, including a comparison page that was
  considered and turned down.

## Verification

`npm run verify` passes, exit 0, no errors or warnings.

Against the built output in `.next/server/app/`:

- landing title 51 characters, rules title 43, description 150, all inside what
  gets shown
- the JSON-LD block parses, `@type` is `VideoGame`, players read 2 to 6, price 0
- `og:title` and `og:description` are unchanged on both pages
- the manifest carries the new description with `name` and `short_name` as they
  were
- `grep -rn "strategy, memory, and luck" client/app/` comes back empty, which is
  the command #156 ends with

This is a client only change, so the preview deployment does exercise it. Worth
pasting the preview URL into Google's Rich Results Test to confirm the
`VideoGame` block is picked up before merging.

No game behaviour is touched, so no probe run and no two window round.

## Not code, and still to do

Search Console URL Inspection, then Request indexing, for `/` and `/rules`.
Sitemap discovery on its own takes weeks where a manual request usually takes
days. That is the highest value step here and it cannot be done from the repo.
