### PR TITLE
Say the server is waking during a cold start

### DIFF
--- a/client/components/modals/ColdStartWaitNotice.tsx
+++ b/client/components/modals/ColdStartWaitNotice.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { motion, AnimatePresence } from "framer-motion";
+import { useUISelector } from "@/context/GameUIContext";
+
+// The live region is mounted whether or not there is anything to say. A screen
+// reader only announces changes inside a region that was already present, so
+// mounting it along with the text would announce nothing.
+export function ColdStartWaitNotice({ className }: { className?: string }) {
+  const phase = useUISelector((s) => s.context.coldStartPhase);
+
+  return (
+    <div aria-live="polite" className={className}>
+      <AnimatePresence mode="wait">
+        {phase !== "silent" && (
+          <motion.p
+            key={phase}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2, ease: "easeOut" }}
+            className="text-xs leading-relaxed text-ink-muted"
+          >
+            {phase === "explaining"
+              ? "The server sleeps when nobody is playing. The first game after a quiet spell takes about a minute."
+              : "The server is waking up."}
+          </motion.p>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/client/components/modals/ColdStartWaitNotice.tsx
+++ b/client/components/modals/ColdStartWaitNotice.tsx
@@ -6,25 +6,57 @@ import { useUISelector } from "@/context/GameUIContext";
 // The live region is mounted whether or not there is anything to say. A screen
 // reader only announces changes inside a region that was already present, so
 // mounting it along with the text would announce nothing.
+//
+// The rule belongs to the second phase alone. It is the heavier treatment, and
+// it earns its place only once the wait is long enough to need explaining.
 export function ColdStartWaitNotice({ className }: { className?: string }) {
   const phase = useUISelector((s) => s.context.coldStartPhase);
 
   return (
     <div aria-live="polite" className={className}>
-      <AnimatePresence mode="wait">
+      <AnimatePresence initial={false}>
         {phase !== "silent" && (
-          <motion.p
-            key={phase}
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.2, ease: "easeOut" }}
-            className="text-xs leading-relaxed text-ink-muted"
+          <motion.div
+            key="notice"
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{
+              height: { duration: 0.32, ease: [0.4, 0, 0.2, 1] },
+              opacity: { duration: 0.22, ease: "easeOut" },
+            }}
+            className="overflow-hidden"
           >
-            {phase === "explaining"
-              ? "The server sleeps when nobody is playing. The first game after a quiet spell takes about a minute."
-              : "The server is waking up."}
-          </motion.p>
+            <motion.div layout="position" className="pt-4">
+              <AnimatePresence initial={false}>
+                {phase === "explaining" && (
+                  <motion.div
+                    key="rule"
+                    initial={{ opacity: 0, scaleX: 0.7 }}
+                    animate={{ opacity: 1, scaleX: 1 }}
+                    exit={{ opacity: 0 }}
+                    transition={{ duration: 0.36, ease: [0.4, 0, 0.2, 1] }}
+                    className="mb-3 h-px origin-left bg-hairline"
+                  />
+                )}
+              </AnimatePresence>
+
+              <AnimatePresence mode="wait" initial={false}>
+                <motion.p
+                  key={phase}
+                  initial={{ opacity: 0, y: 3 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: -3 }}
+                  transition={{ duration: 0.16, ease: "easeOut" }}
+                  className="text-xs leading-relaxed text-ink-muted"
+                >
+                  {phase === "explaining"
+                    ? "The server sleeps when nobody is playing, so the first game takes about a minute."
+                    : "The server is waking up."}
+                </motion.p>
+              </AnimatePresence>
+            </motion.div>
+          </motion.div>
         )}
       </AnimatePresence>
     </div>

--- a/client/components/modals/JoinGameModal.tsx
+++ b/client/components/modals/JoinGameModal.tsx
@@ -184,7 +184,7 @@ export function JoinGameModal({
           </button>
         </div>
 
-        <ColdStartWaitNotice className="mt-4" />
+        <ColdStartWaitNotice />
       </DialogContent>
     </Dialog>
   );

--- a/client/components/modals/JoinGameModal.tsx
+++ b/client/components/modals/JoinGameModal.tsx
@@ -11,6 +11,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { useUISelector, useUIActorRef } from "@/context/GameUIContext";
+import { ColdStartWaitNotice } from "@/components/modals/ColdStartWaitNotice";
 
 interface JoinGameModalProps {
   isModalOpen: boolean;
@@ -182,6 +183,8 @@ export function JoinGameModal({
             )}
           </button>
         </div>
+
+        <ColdStartWaitNotice className="mt-4" />
       </DialogContent>
     </Dialog>
   );

--- a/client/components/modals/NewGameModal.tsx
+++ b/client/components/modals/NewGameModal.tsx
@@ -10,6 +10,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { useUIActorRef, useUISelector } from "@/context/GameUIContext";
+import { ColdStartWaitNotice } from "@/components/modals/ColdStartWaitNotice";
 import { cn } from "@/lib/utils";
 
 interface NewGameModalProps {
@@ -134,6 +135,8 @@ export function NewGameModal({
             )}
           </button>
         </div>
+
+        <ColdStartWaitNotice className="mt-4" />
       </DialogContent>
     </Dialog>
   );

--- a/client/components/modals/NewGameModal.tsx
+++ b/client/components/modals/NewGameModal.tsx
@@ -136,7 +136,7 @@ export function NewGameModal({
           </button>
         </div>
 
-        <ColdStartWaitNotice className="mt-4" />
+        <ColdStartWaitNotice />
       </DialogContent>
     </Dialog>
   );

--- a/client/components/modals/RejoinModal.tsx
+++ b/client/components/modals/RejoinModal.tsx
@@ -8,6 +8,7 @@ import {
   useUISelector,
   type UIMachineSnapshot,
 } from "@/context/GameUIContext";
+import { ColdStartWaitNotice } from "@/components/modals/ColdStartWaitNotice";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -162,6 +163,8 @@ export function RejoinModal() {
                     No thanks, take me home
                   </button>
                 </div>
+
+                <ColdStartWaitNotice className="mt-4 text-center" />
               </form>
             </motion.div>
           </DialogContent>

--- a/client/components/modals/RejoinModal.tsx
+++ b/client/components/modals/RejoinModal.tsx
@@ -164,7 +164,7 @@ export function RejoinModal() {
                   </button>
                 </div>
 
-                <ColdStartWaitNotice className="mt-4 text-center" />
+                <ColdStartWaitNotice className="text-center" />
               </form>
             </motion.div>
           </DialogContent>

--- a/client/machines/uiMachine.ts
+++ b/client/machines/uiMachine.ts
@@ -37,6 +37,21 @@ const PEEK_ABILITY_DURATION_MS = 5000;
 const ACTION_ANSWER_TIMEOUT_MS = 8000;
 const INITIAL_PEEK_DURATION_MS = 10000;
 
+// A free-tier server spins down after 15 minutes idle and takes roughly a
+// minute to answer the first request after that. HANDSHAKE_TIMEOUT_MS in
+// actors.ts is sized to cover it, so the request is working the whole time.
+// These phases exist because nothing on screen said so: a spinner that has not
+// moved in forty seconds reads as a hang, and the reasonable response to a
+// hang is a reload, which throws away the wake already paid for.
+const WAKE_HINT_AFTER_MS = 3000;
+const WAKE_EXPLAIN_AFTER_MS = 15000;
+
+// Named so the exit action can cancel them. A raise still in flight when the
+// wait ends would otherwise land in whatever state follows and show the notice
+// over a screen that is not waiting for anything.
+const COLD_START_HINT_ID = "coldStartHint";
+const COLD_START_EXPLAIN_ID = "coldStartExplain";
+
 type ServerToClientEvents =
   | { type: "CLIENT_GAME_STATE_UPDATED"; gameState: ClientCheckGameState }
   | { type: "NEW_GAME_LOG"; logMessage: RichGameLogMessage }
@@ -93,6 +108,9 @@ export interface UIMachineContext {
   /** Date.now() when the last game action was emitted; null once any state
    *  update lands. Drives the action bar's in-flight disable. */
   pendingActionSince: number | null;
+  /** How much the modals say about a wait that is still in flight. Escalates on
+   *  elapsed time alone, so a cold server's minute does not read as a hang. */
+  coldStartPhase: "silent" | "waking" | "explaining";
 }
 
 export type UIMachineEvents =
@@ -112,6 +130,8 @@ export type UIMachineEvents =
     }
   | { type: "ACTION_NOT_SENT" }
   | { type: "ACTION_UNANSWERED" }
+  | { type: "_COLD_START_WAKING" }
+  | { type: "_COLD_START_EXPLAINING" }
   | { type: "SEAT_CLAIMED_ELSEWHERE" }
   | { type: "CONFIRM_ABILITY_ACTION" }
   | { type: "SKIP_ABILITY_STAGE" }
@@ -337,6 +357,22 @@ export const uiMachine = setup({
       visibleCards: [],
       reconnectionAttempts: 0,
       pendingActionSince: null,
+    }),
+    armColdStartPhases: enqueueActions(({ enqueue }) => {
+      enqueue.assign({ coldStartPhase: "silent" as const });
+      enqueue.raise(
+        { type: "_COLD_START_WAKING" },
+        { delay: WAKE_HINT_AFTER_MS, id: COLD_START_HINT_ID },
+      );
+      enqueue.raise(
+        { type: "_COLD_START_EXPLAINING" },
+        { delay: WAKE_EXPLAIN_AFTER_MS, id: COLD_START_EXPLAIN_ID },
+      );
+    }),
+    disarmColdStartPhases: enqueueActions(({ enqueue }) => {
+      enqueue.cancel(COLD_START_HINT_ID);
+      enqueue.cancel(COLD_START_EXPLAIN_ID);
+      enqueue.assign({ coldStartPhase: "silent" as const });
     }),
     markActionPending: enqueueActions(({ enqueue }) => {
       enqueue.assign({ pendingActionSince: () => Date.now() });
@@ -749,6 +785,7 @@ export const uiMachine = setup({
     lastStateReceivedAt: 0,
     modal: null,
     pendingActionSince: null,
+    coldStartPhase: "silent",
   }),
   initial: "initializing",
   on: {
@@ -766,6 +803,12 @@ export const uiMachine = setup({
       ],
     },
     ERROR_RECEIVED: { actions: "showErrorToast" },
+    _COLD_START_WAKING: {
+      actions: assign({ coldStartPhase: "waking" as const }),
+    },
+    _COLD_START_EXPLAINING: {
+      actions: assign({ coldStartPhase: "explaining" as const }),
+    },
     // The bridge refused to put a move on a dead socket. Clear the in-flight
     // state now rather than letting the action bar grey out for its full
     // unstick delay over a move that was never sent.
@@ -806,6 +849,8 @@ export const uiMachine = setup({
         idle: { tags: ["idle"] },
         creatingGame: {
           tags: ["loading"],
+          entry: "armColdStartPhases",
+          exit: "disarmColdStartPhases",
           invoke: {
             src: "createGame",
             input: ({ event }) => {
@@ -830,6 +875,8 @@ export const uiMachine = setup({
         },
         joiningGame: {
           tags: ["loading"],
+          entry: "armColdStartPhases",
+          exit: "disarmColdStartPhases",
           invoke: {
             src: "joinGame",
             input: ({ event }) => {
@@ -1245,6 +1292,8 @@ export const uiMachine = setup({
         },
         joiningGame: {
           tags: ["loading"],
+          entry: "armColdStartPhases",
+          exit: "disarmColdStartPhases",
           // The server broadcasts the post-join state BEFORE the join ack
           // reaches this client (the machine's broadcast is emitted
           // synchronously inside the join send). The inGame-level handler

--- a/client/machines/uiMachine.ts
+++ b/client/machines/uiMachine.ts
@@ -43,8 +43,15 @@ const INITIAL_PEEK_DURATION_MS = 10000;
 // These phases exist because nothing on screen said so: a spinner that has not
 // moved in forty seconds reads as a hang, and the reasonable response to a
 // hang is a reload, which throws away the wake already paid for.
-const WAKE_HINT_AFTER_MS = 3000;
-const WAKE_EXPLAIN_AFTER_MS = 15000;
+//
+// Both thresholds are measured, not guessed. A warm production create takes up
+// to 2.5s end to end, because the emit waits on a socket that itself needs a
+// couple of seconds, so anything under about 4s fires at a healthy server.
+// The far end is bounded by the player: they start reloading around 20s, so
+// the explanation has to be on screen well before that or it arrives too late
+// to stop the thing it exists to prevent.
+const WAKE_HINT_AFTER_MS = 5000;
+const WAKE_EXPLAIN_AFTER_MS = 12000;
 
 // Named so the exit action can cancel them. A raise still in flight when the
 // wait ends would otherwise land in whatever state follows and show the notice


### PR DESCRIPTION
A free instance spins down after 15 minutes idle and takes roughly a minute to answer the first request after that. The request is working the whole time, and `HANDSHAKE_TIMEOUT_MS` is already sized to cover it, but the loading state looked identical at one second and at fifty. A spinner that has not moved in forty seconds reads as a hang, and the sensible response to a hang is a reload, which throws away the wake already paid for and starts another one.

## What changed

The three loading states behind the 60 second ack (`outOfGame.creatingGame`, `outOfGame.joiningGame`, `inGame.joiningGame`) arm two delayed raises on entry and cancel them on exit. `coldStartPhase` in context escalates `silent` to `waking` at 3s to `explaining` at 15s. One shared `ColdStartWaitNotice` renders the copy, so all three modals say the same thing from one file.

A warm request says nothing at all. The escalation is driven by elapsed time only, never by anything the request reports.

`inGame.reconnecting` also carries the `loading` tag and is deliberately left alone: that is an established session, and `GameBoard` already has its own reconnecting UI.

## Delayed raises rather than `after`

The machine has never used `after`, and delayed `raise` with a cancellation id is the idiom already here (`markActionPending`). Naming the ids matters: a raise still in flight when the wait ends would otherwise land in whatever state follows and show the notice over a screen that is not waiting for anything. The exit action cancels both.

## Verification

Unverified by real play. What did run:

- `npm run verify` passes.
- A repro drives the real `uiMachine` with the invoked actors stubbed and a simulated clock, asserting the timeline in all three states: silent at 2.9s, waking at 3.0s, still waking at 14.9s, explaining at 15.0s, still explaining at 60s. It also asserts a warm answer at 1.2s never shows a message, and that broadcasts arriving during `inGame.joiningGame` do not disturb the phases.
- Both phases confirmed rendering in a browser at 390px wide, against a server address that never answers.

## Still open

Whether that repro should become a committed `check:` script in `verify`. It needs `jiti`, which is currently only a transitive dependency of tailwind and eslint, so a gate built on it would break the day either drops it. Making it permanent means adding `jiti` as an explicit devDependency, which felt like a separate decision from this change.
