### PR TITLE
Identify player name fields as nicknames

### DIFF
--- a/client/components/modals/JoinGameModal.tsx
+++ b/client/components/modals/JoinGameModal.tsx
@@ -110,11 +110,13 @@ export function JoinGameModal({
                 </label>
                 <input
                   id="player-name"
+                  type="text"
+                  name="playerNickname"
                   value={playerName}
                   onChange={(e) => setPlayerName(e.target.value)}
                   placeholder="Enter your name"
                   onKeyDown={onKeyDown}
-                  autoComplete="off"
+                  autoComplete="nickname"
                   autoFocus
                   maxLength={20}
                   className="mt-2 h-12 w-full rounded-full border border-hairline bg-surface px-5 text-base text-ink outline-none transition-colors placeholder:text-ink-muted focus:border-accent"

--- a/client/components/modals/NewGameModal.tsx
+++ b/client/components/modals/NewGameModal.tsx
@@ -75,11 +75,13 @@ export function NewGameModal({
           </label>
           <input
             id="name"
+            type="text"
+            name="playerNickname"
             placeholder="Enter your name"
             value={playerName}
             onChange={(e) => setPlayerName(e.target.value)}
             onKeyDown={onKeyDown}
-            autoComplete="off"
+            autoComplete="nickname"
             autoFocus
             maxLength={20}
             className="mt-2 h-12 w-full rounded-full border border-hairline bg-surface px-5 text-base text-ink outline-none transition-colors placeholder:text-ink-muted focus:border-accent"

--- a/client/components/modals/RejoinModal.tsx
+++ b/client/components/modals/RejoinModal.tsx
@@ -125,12 +125,14 @@ export function RejoinModal() {
                     </Label>
                     <Input
                       id="player-name-rejoin"
+                      type="text"
+                      name="playerNickname"
                       value={playerName}
                       onChange={(e) => setPlayerName(e.target.value)}
                       placeholder="Enter your name"
                       className="rounded-xl border-hairline bg-surface h-12 px-4 text-lg text-center"
                       onKeyDown={onKeyDown}
-                      autoComplete="off"
+                      autoComplete="nickname"
                       autoFocus
                     />
                   </div>


### PR DESCRIPTION
Fixes #169

## What this changes

Marks all three player-name controls as text fields named playerNickname with the standard nickname autocomplete purpose. The game-code field keeps autocomplete disabled, and the existing focus, storage and submission paths are unchanged.

## How it was verified

- npm run verify
- Confirmed all three player-name controls carry name=playerNickname and autoComplete=nickname.
- Confirmed the only remaining autoComplete=off in these modals belongs to the game-code field.

The Android autofill accessory depends on the browser profile, so the reported device still needs to check the Vercel preview before merge.