### PR TITLE
Stop auto-focusing player name fields

### DIFF
--- a/client/components/modals/JoinGameModal.tsx
+++ b/client/components/modals/JoinGameModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { toast } from "sonner";
 import { motion, AnimatePresence } from "framer-motion";
 import { ArrowRight, Loader2 } from "lucide-react";
@@ -22,6 +22,7 @@ export function JoinGameModal({
   isModalOpen,
   setIsModalOpen,
 }: JoinGameModalProps) {
+  const titleRef = useRef<HTMLHeadingElement>(null);
   const [gameId, setGameId] = useState("");
   const [playerName, setPlayerName] = useState(() => {
     if (typeof localStorage !== "undefined") {
@@ -75,6 +76,10 @@ export function JoinGameModal({
   return (
     <Dialog open={isModalOpen} onOpenChange={resetAndClose}>
       <DialogContent
+        onOpenAutoFocus={(event) => {
+          event.preventDefault();
+          titleRef.current?.focus();
+        }}
         onInteractOutside={(e) => {
           if (isLoading) e.preventDefault();
         }}
@@ -83,7 +88,11 @@ export function JoinGameModal({
         <p className="text-xs font-semibold uppercase tracking-widest text-ink-muted">
           Join a table · step {step} of 2
         </p>
-        <DialogTitle className="mt-2 text-3xl font-extrabold tracking-tight text-ink">
+        <DialogTitle
+          ref={titleRef}
+          tabIndex={-1}
+          className="mt-2 text-3xl font-extrabold tracking-tight text-ink"
+        >
           Join a game
         </DialogTitle>
         <DialogDescription className="mt-2 text-sm leading-relaxed text-ink-muted">
@@ -111,13 +120,11 @@ export function JoinGameModal({
                 <input
                   id="player-name"
                   type="text"
-                  name="playerNickname"
                   value={playerName}
                   onChange={(e) => setPlayerName(e.target.value)}
                   placeholder="Enter your name"
                   onKeyDown={onKeyDown}
-                  autoComplete="nickname"
-                  autoFocus
+                  autoComplete="off"
                   maxLength={20}
                   className="mt-2 h-12 w-full rounded-full border border-hairline bg-surface px-5 text-base text-ink outline-none transition-colors placeholder:text-ink-muted focus:border-accent"
                 />

--- a/client/components/modals/NewGameModal.tsx
+++ b/client/components/modals/NewGameModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { toast } from "sonner";
 import { ArrowRight, Loader2 } from "lucide-react";
 import {
@@ -22,6 +22,7 @@ export function NewGameModal({
   isModalOpen,
   setIsModalOpen,
 }: NewGameModalProps) {
+  const titleRef = useRef<HTMLHeadingElement>(null);
   const [playerName, setPlayerName] = useState(() => {
     if (typeof localStorage !== "undefined") {
       return localStorage.getItem("localPlayerName") || "";
@@ -53,6 +54,10 @@ export function NewGameModal({
   return (
     <Dialog open={isModalOpen} onOpenChange={setIsModalOpen}>
       <DialogContent
+        onOpenAutoFocus={(event) => {
+          event.preventDefault();
+          titleRef.current?.focus();
+        }}
         onInteractOutside={(e) => {
           if (isLoading) e.preventDefault();
         }}
@@ -61,7 +66,11 @@ export function NewGameModal({
         <p className="text-xs font-semibold uppercase tracking-widest text-ink-muted">
           New table
         </p>
-        <DialogTitle className="mt-2 text-3xl font-extrabold tracking-tight text-ink">
+        <DialogTitle
+          ref={titleRef}
+          tabIndex={-1}
+          className="mt-2 text-3xl font-extrabold tracking-tight text-ink"
+        >
           Create a game
         </DialogTitle>
         <DialogDescription className="mt-2 text-sm leading-relaxed text-ink-muted">
@@ -76,13 +85,11 @@ export function NewGameModal({
           <input
             id="name"
             type="text"
-            name="playerNickname"
             placeholder="Enter your name"
             value={playerName}
             onChange={(e) => setPlayerName(e.target.value)}
             onKeyDown={onKeyDown}
-            autoComplete="nickname"
-            autoFocus
+            autoComplete="off"
             maxLength={20}
             className="mt-2 h-12 w-full rounded-full border border-hairline bg-surface px-5 text-base text-ink outline-none transition-colors placeholder:text-ink-muted focus:border-accent"
           />

--- a/client/components/modals/RejoinModal.tsx
+++ b/client/components/modals/RejoinModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { motion, AnimatePresence } from "framer-motion";
 import {
@@ -31,6 +31,7 @@ const selectRejoinModalProps = (state: UIMachineSnapshot) => {
 };
 
 export function RejoinModal() {
+  const titleRef = useRef<HTMLHeadingElement>(null);
   const { send } = useUIActorRef();
   const { gameId, modalInfo, isLoading } = useUISelector(
     selectRejoinModalProps,
@@ -43,14 +44,6 @@ export function RejoinModal() {
     }
     return "";
   });
-
-  useEffect(() => {
-    if (modalInfo?.type === "rejoin") {
-      setTimeout(() => {
-        document.getElementById("player-name-rejoin")?.focus();
-      }, 100);
-    }
-  }, [modalInfo]);
 
   const isVisible = modalInfo?.type === "rejoin";
 
@@ -89,6 +82,10 @@ export function RejoinModal() {
         {isVisible && (
           <DialogContent
             showCloseButton={false}
+            onOpenAutoFocus={(event) => {
+              event.preventDefault();
+              titleRef.current?.focus();
+            }}
             onInteractOutside={(e) => e.preventDefault()}
             onEscapeKeyDown={(e) => e.preventDefault()}
             className="sm:max-w-md p-0 overflow-hidden bg-surface border-hairline rounded-xl border"
@@ -105,7 +102,11 @@ export function RejoinModal() {
                     <div className="rounded-full bg-surface-2 p-2">
                       <Users className="h-5 w-5 text-ink-muted" />
                     </div>
-                    <DialogTitle className="text-3xl font-bold text-ink">
+                    <DialogTitle
+                      ref={titleRef}
+                      tabIndex={-1}
+                      className="text-3xl font-bold text-ink"
+                    >
                       {modalInfo?.title || "Join Game"}
                     </DialogTitle>
                   </div>
@@ -126,14 +127,12 @@ export function RejoinModal() {
                     <Input
                       id="player-name-rejoin"
                       type="text"
-                      name="playerNickname"
                       value={playerName}
                       onChange={(e) => setPlayerName(e.target.value)}
                       placeholder="Enter your name"
                       className="rounded-xl border-hairline bg-surface h-12 px-4 text-lg text-center"
                       onKeyDown={onKeyDown}
-                      autoComplete="nickname"
-                      autoFocus
+                      autoComplete="off"
                     />
                   </div>
                 </div>


### PR DESCRIPTION
## Summary

- focus each player-entry dialog heading instead of its name input when the dialog opens
- set all player-name inputs to autocomplete=off and remove the unnecessary playerNickname field name
- remove the invite flow's redundant delayed focus timer
- preserve intentional game-code focus after Continue and the existing localPlayerName prefill

## Verification

- npm run verify
- mobile-sized Chromium focus probe covering Create, Join, game-code transition, and invite entry

The browser probe confirmed that every player-entry dialog initially focuses its H2, every player-name input remains unfocused with autocomplete=off, and the game-code field still receives focus after Continue.

Fixes #169